### PR TITLE
Fix simulator auto-fill missing NiP matches via initialism name matching

### DIFF
--- a/src/PickemsPlanter/Services/PandaScoreResultsService.cs
+++ b/src/PickemsPlanter/Services/PandaScoreResultsService.cs
@@ -79,9 +79,17 @@ public partial class PandaScoreResultsService(IPandaScoreResultsCachingService c
 			.Where(x =>
 			{
 				string normalizedTeamName = Normalize(x.Name!);
-				return normalizedTeamName == normalizedPandaScoreName
+
+				if (normalizedTeamName == normalizedPandaScoreName
 					|| normalizedTeamName.Contains(normalizedPandaScoreName)
-					|| normalizedPandaScoreName.Contains(normalizedTeamName);
+					|| normalizedPandaScoreName.Contains(normalizedTeamName))
+					return true;
+
+				// Some orgs are commonly referred to by an initialism of their full name
+				// (eg. "NiP" for "Ninjas in Pyjamas") — the initials aren't a contiguous
+				// substring of the space-stripped name, so the checks above miss it.
+				return GetInitials(x.Name!) == normalizedPandaScoreName
+					|| GetInitials(pandaScoreTeamName) == normalizedTeamName;
 			})
 			.ToList();
 
@@ -90,6 +98,9 @@ public partial class PandaScoreResultsService(IPandaScoreResultsCachingService c
 
 	private static string Normalize(string name) =>
 		string.Concat(name.Where(char.IsLetterOrDigit)).ToLowerInvariant();
+
+	private static string GetInitials(string name) =>
+		string.Concat(name.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(word => word[0])).ToLowerInvariant();
 
 	private static int? ParseRound(string matchName)
 	{

--- a/tests/PickemsPlanter.Tests/Services/PandaScoreResultsServiceTests.cs
+++ b/tests/PickemsPlanter.Tests/Services/PandaScoreResultsServiceTests.cs
@@ -189,6 +189,47 @@ public class PandaScoreResultsServiceTests
 		Assert.Empty(result);
 	}
 
+	[Theory]
+	[InlineData("NiP", "Ninjas in Pyjamas", "nip")]
+	[InlineData("Ninjas in Pyjamas", "NiP", "nip")]
+	public async Task GetCompletedMatchesAsync_ResolvesTeam_WhenPandaScoreNameIsAnInitialismOfSteamName(
+		string pandaScoreName, string steamName, string logo)
+	{
+		// Arrange — an initialism (eg. "NiP" for "Ninjas in Pyjamas") isn't a contiguous
+		// substring of the space-stripped full name, so the substring fallback alone misses it.
+		string eventId = "25";
+		Stages stage = Stages.Stage1;
+
+		List<Team> teams =
+		[
+			new() { Name = steamName, Logo = logo },
+			new() { Name = "BIG", Logo = "big" }
+		];
+
+		PandaScoreMatch match = new()
+		{
+			Id = 1,
+			Name = "Round 1: X vs Y",
+			Status = "finished",
+			WinnerId = 3249,
+			Opponents =
+			[
+				new() { Opponent = new PandaScoreTeam { Id = 3249, Name = pandaScoreName } },
+				new() { Opponent = new PandaScoreTeam { Id = 3256, Name = "BIG" } }
+			]
+		};
+
+		_cachingService.GetCompletedMatches(eventId, stage).Returns([match]);
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(teams);
+
+		// Act
+		var result = await _service.GetCompletedMatchesAsync(eventId, stage);
+
+		// Assert
+		var single = Assert.Single(result);
+		Assert.Equal($"{logo}.png", single.WinnerTeam);
+	}
+
 	[Fact]
 	public async Task GetCompletedMatchesAsync_SkipsMatch_WhenNameHasNoRoundPrefix()
 	{


### PR DESCRIPTION
## Summary
- PandaScore refers to Ninjas in Pyjamas as the initialism "NiP", which isn't a contiguous substring of the space-stripped Steam name "Ninjas in Pyjamas" — so the existing normalized-substring fallback in `PandaScoreResultsService.ResolveLogoFileName` silently skipped the match, leaving that team's round-0 matchup undecided in the Simulator.
- Confirmed against live event 25 data: the only two round-0 Swiss matches missing from Stage1/Stage2 auto-fill results both involved the `nip` team, matching the two blank matchups reported.
- Adds an initials-based fallback (first letter of each word in the full org name) alongside the existing substring check, in both directions, still only committing when it resolves to exactly one unambiguous team.

## Test plan
- [x] `dotnet test src/PickemsPlanter.sln --filter "FullyQualifiedName~PandaScoreResultsServiceTests"` — new `NiP` ↔ `Ninjas in Pyjamas` theory cases pass in both directions
- [x] `dotnet test src/PickemsPlanter.sln` — full suite passes (54/54)

🤖 Generated with [Claude Code](https://claude.com/claude-code)