### PR TITLE
Add custom hover tooltip for team names

### DIFF
--- a/src/PickemsPlanter/wwwroot/css/site.css
+++ b/src/PickemsPlanter/wwwroot/css/site.css
@@ -16,6 +16,32 @@
     --shadow-l: 0 10px 20px rgba(0,0,0,0.6), 0 4px 8px rgba(0,0,0,0.3);
 }
 
+.team-tooltip {
+    position: fixed;
+    z-index: 1000;
+    padding: 6px 12px;
+    border-radius: 8px;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    box-shadow: var(--shadow-m);
+    backdrop-filter: blur(8px);
+    color: var(--text-colour);
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(4px);
+    transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.team-tooltip.show {
+    opacity: 1;
+    transform: translateY(0);
+}
+
 body {
     font-family: stratum-1-web, sans-serif;
     background: radial-gradient(ellipse at 50% 0%, #16213a 0%, var(--background-colour) 65%);

--- a/src/PickemsPlanter/wwwroot/js/PickEms/apiFunctions.js
+++ b/src/PickemsPlanter/wwwroot/js/PickEms/apiFunctions.js
@@ -37,8 +37,6 @@ async function LoadImagesAsync() {
             const teamImage = createTeamImage(imageSource);
             container.appendChild(teamImage);
 
-            mapElementTitle(imageSource, container);
-
             container.setAttribute('disabled', 'true');
 
             container.addEventListener('dragstart', (e) => e.preventDefault());
@@ -89,8 +87,6 @@ async function LoadPicksAsync() {
 
                 setDropzoneClassName(dropzone, false);
             }
-
-            mapElementTitle(imageSource, dropzone);
         }
     }
     else {
@@ -139,8 +135,6 @@ async function LoadResultsAsync() {
             toggleCheckmark(index, resultImageSource);
 
             setDropzoneClassName(dropzone, true);
-
-            mapElementTitle(imageSource, dropzone);
         }
     }
 

--- a/src/PickemsPlanter/wwwroot/js/PickEms/dropzoneFunctions.js
+++ b/src/PickemsPlanter/wwwroot/js/PickEms/dropzoneFunctions.js
@@ -59,8 +59,6 @@ function clearAllDropzones() {
 }
 
 function swapImagesInDropzones(originDropzone, destinationDropzone) {
-    const destinationImageSrc = destinationDropzone.querySelector('.dropped-img').src;
-
     originDropzone.innerHTML = destinationDropzone.innerHTML;
 
     destinationDropzone.innerHTML = '';
@@ -69,9 +67,6 @@ function swapImagesInDropzones(originDropzone, destinationDropzone) {
     currentDraggedElement.className = 'dropped-img';
     destinationDropzone.appendChild(currentDraggedElement);
     destinationDropzone.classList.remove('drag-hover');
-
-    mapElementTitle(destinationImageSrc, originDropzone);
-    mapElementTitle(currentDraggedElement.src, destinationDropzone);
 
     updateSaveButton();
     resetGlobals();
@@ -176,8 +171,6 @@ function placeImageInDropzone(imageSource, dropzone, isResults) {
         greyOutImages();
         resetEliminatedImages();
     }
-
-    mapElementTitle(imageSource, dropzone);
 
     resetGlobals();
 

--- a/src/PickemsPlanter/wwwroot/js/PickEms/randomPicksFunctions.js
+++ b/src/PickemsPlanter/wwwroot/js/PickEms/randomPicksFunctions.js
@@ -67,7 +67,6 @@ function selectRandomPicks() {
             const randomTeam = teamImageSources[randomIndex];
 
             placeImageInDropzone(randomTeam, dropzone, false, false);
-            mapElementTitle(randomTeam, dropzone);
 
             teamImageSources.splice(randomIndex, 1);
         }

--- a/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
+++ b/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
@@ -31,8 +31,8 @@ function positionTeamTooltip(tooltip, target) {
     let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
     left = Math.max(4, Math.min(left, window.innerWidth - tooltipRect.width - 4));
 
-    const spaceAbove = targetRect.top - tooltipRect.height - 8;
-    const top = spaceAbove >= 0 ? spaceAbove : targetRect.bottom + 8;
+    const spaceBelow = window.innerHeight - (targetRect.bottom + tooltipRect.height + 8);
+    const top = spaceBelow >= 0 ? targetRect.bottom + 8 : targetRect.top - tooltipRect.height - 8;
 
     tooltip.style.left = `${left}px`;
     tooltip.style.top = `${top}px`;

--- a/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
+++ b/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
@@ -1,6 +1,6 @@
-﻿function mapElementTitle(image, dropzone) {
-    const logo = image.split('/').pop().split('.')[0];
-    dropzone.title = (typeof teamNameMap !== 'undefined' ? teamNameMap[logo] : null) ?? logo;
+﻿function resolveTeamTitle(imageSource) {
+    const logo = imageSource.split('/').pop().split('.')[0];
+    return (typeof teamNameMap !== 'undefined' ? teamNameMap[logo] : null) ?? logo;
 }
 
 function updateSaveButton() {
@@ -200,6 +200,7 @@ function createTeamImage(imageSource) {
     const image = document.createElement("img");
     image.src = imageSource;
     image.className = "team-img";
+    image.title = resolveTeamTitle(imageSource);
 
     if (imageSource.includes('unknown'))
         image.classList.add('unknown');
@@ -211,6 +212,7 @@ function createDroppedImage(imageSource) {
     const image = document.createElement("img");
     image.src = imageSource;
     image.className = "dropped-img";
+    image.title = resolveTeamTitle(imageSource);
 
     return image;
 }

--- a/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
+++ b/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
@@ -3,6 +3,55 @@
     return (typeof teamNameMap !== 'undefined' ? teamNameMap[logo] : null) ?? logo;
 }
 
+// Single delegated listener covers every team image on the page — Simple View source
+// cards, dropzones, and the Swiss bracket's own internal team images alike — with no
+// per-callsite wiring needed, and no dependency on teamNameMap being populated yet by
+// the time an image is created (resolveTeamTitle is looked up live, on hover).
+let teamTooltipElement = null;
+
+function isTeamImageElement(element) {
+    return element instanceof HTMLImageElement
+        && (element.classList.contains('team-img') || element.classList.contains('dropped-img'));
+}
+
+function ensureTeamTooltipElement() {
+    if (!teamTooltipElement) {
+        teamTooltipElement = document.createElement('div');
+        teamTooltipElement.className = 'team-tooltip';
+        document.body.appendChild(teamTooltipElement);
+    }
+
+    return teamTooltipElement;
+}
+
+function positionTeamTooltip(tooltip, target) {
+    const targetRect = target.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+
+    let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
+    left = Math.max(4, Math.min(left, window.innerWidth - tooltipRect.width - 4));
+
+    const spaceAbove = targetRect.top - tooltipRect.height - 8;
+    const top = spaceAbove >= 0 ? spaceAbove : targetRect.bottom + 8;
+
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+}
+
+document.addEventListener('mouseover', (event) => {
+    if (!isTeamImageElement(event.target)) return;
+
+    const tooltip = ensureTeamTooltipElement();
+    tooltip.textContent = resolveTeamTitle(event.target.src);
+    positionTeamTooltip(tooltip, event.target);
+    tooltip.classList.add('show');
+});
+
+document.addEventListener('mouseout', (event) => {
+    if (!isTeamImageElement(event.target)) return;
+    if (teamTooltipElement) teamTooltipElement.classList.remove('show');
+});
+
 function updateSaveButton() {
     const saveButton = document.getElementById('saveButton');
 
@@ -200,7 +249,6 @@ function createTeamImage(imageSource) {
     const image = document.createElement("img");
     image.src = imageSource;
     image.className = "team-img";
-    image.title = resolveTeamTitle(imageSource);
 
     if (imageSource.includes('unknown'))
         image.classList.add('unknown');
@@ -212,7 +260,6 @@ function createDroppedImage(imageSource) {
     const image = document.createElement("img");
     image.src = imageSource;
     image.className = "dropped-img";
-    image.title = resolveTeamTitle(imageSource);
 
     return image;
 }

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -297,6 +297,7 @@ function createBracketTeamImage(imageSource, seed, buchholz) {
     const image = document.createElement("img");
     image.src = `https://sacs2.blob.core.windows.net/teamimages/${imageSource}`;
     image.className = "team-img";
+    image.title = resolveTeamTitle(imageSource);
     image.setAttribute('seed', seed);
     image.setAttribute('buchholz', buchholz);
 

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -297,7 +297,6 @@ function createBracketTeamImage(imageSource, seed, buchholz) {
     const image = document.createElement("img");
     image.src = `https://sacs2.blob.core.windows.net/teamimages/${imageSource}`;
     image.className = "team-img";
-    image.title = resolveTeamTitle(imageSource);
     image.setAttribute('seed', seed);
     image.setAttribute('buchholz', buchholz);
 


### PR DESCRIPTION
## Summary
- Closes #132. Team logos across Pick'Ems (Simple View, dropzones) and the Swiss bracket (Bracket View, Simulator) now show the team's full name on hover.
- Replaces the old `mapElementTitle()` pattern, which had to be manually invoked at every single call site where a team image was placed — and was missing entirely from the bracket engine's own image creation (`createBracketTeamImage`), so Bracket View never had tooltips at all.
- Instead, a single delegated `mouseover`/`mouseout` listener on `document` matches any `.team-img`/`.dropped-img` element and resolves the team name live at hover time via `teamNameMap` (sourced from Steam team data). This also sidesteps a race where Bracket View — often the default stored view — could render its images before the name map fetch resolved, which previously showed the raw logo filename instead of the team name.
- Swaps the native browser `title` tooltip for a custom glassmorphism-styled tooltip matching the rest of the app's theme (`site.css`), positioned below the hovered logo (falling back to above if there isn't room below the viewport).

## Test plan
- [x] Hover team logos in Simple View (source cards and filled dropzones) on `/PickEms/Stage` and `/PickEms/Playoffs` — full team name shows in the styled tooltip.
- [x] Toggle to Bracket View and hover teams throughout the bracket (round 0 seeds and later rounds) — tooltip shows the correct team name, not the logo filename.
- [x] Confirm no native browser tooltip appears alongside the custom one.
- [x] Confirm tooltip repositions sensibly near viewport edges.