### PR TITLE
Highlight in-progress matches in Bracket View

### DIFF
--- a/src/PickemsPlanter/Models/Simulator/SimulatorLiveMatch.cs
+++ b/src/PickemsPlanter/Models/Simulator/SimulatorLiveMatch.cs
@@ -1,0 +1,8 @@
+namespace PickemsPlanter.Models.Simulator;
+
+public class SimulatorLiveMatch
+{
+	public required string TeamA { get; init; }
+
+	public required string TeamB { get; init; }
+}

--- a/src/PickemsPlanter/Pages/Simulator.cshtml.cs
+++ b/src/PickemsPlanter/Pages/Simulator.cshtml.cs
@@ -22,4 +22,9 @@ public class SimulatorModel(ISeedsService seedsService, IPandaScoreResultsServic
 	{
 		return new JsonResult(await pandaScoreResultsService.GetCompletedMatchesAsync(EventId, Stage));
 	}
+
+	public async Task<JsonResult> OnGetLiveMatches()
+	{
+		return new JsonResult(await pandaScoreResultsService.GetLiveMatchesAsync(EventId, Stage));
+	}
 }

--- a/src/PickemsPlanter/Services/PandaScoreResultsCachingService.cs
+++ b/src/PickemsPlanter/Services/PandaScoreResultsCachingService.cs
@@ -10,6 +10,7 @@ namespace PickemsPlanter.Services;
 public interface IPandaScoreResultsCachingService
 {
 	IReadOnlyCollection<PandaScoreMatch> GetCompletedMatches(string eventId, Stages stage);
+	IReadOnlyCollection<PandaScoreMatch> GetLiveMatches(string eventId, Stages stage);
 }
 
 public class PandaScoreResultsCachingService(
@@ -53,6 +54,14 @@ public class PandaScoreResultsCachingService(
 	public IReadOnlyCollection<PandaScoreMatch> GetCompletedMatches(string eventId, Stages stage)
 	{
 		if (cache.TryGetValue(CacheKey(eventId, stage), out IReadOnlyCollection<PandaScoreMatch>? matches) && matches is not null)
+			return matches;
+
+		return [];
+	}
+
+	public IReadOnlyCollection<PandaScoreMatch> GetLiveMatches(string eventId, Stages stage)
+	{
+		if (cache.TryGetValue(LiveCacheKey(eventId, stage), out IReadOnlyCollection<PandaScoreMatch>? matches) && matches is not null)
 			return matches;
 
 		return [];
@@ -102,8 +111,14 @@ public class PandaScoreResultsCachingService(
 			.Where(m => m.Status == "finished" && m.WinnerId is not null)
 			.ToList();
 
+		var live = matches
+			.Where(m => m.Status == "running")
+			.ToList();
+
 		cache.Set(CacheKey(eventId, stage), (IReadOnlyCollection<PandaScoreMatch>)completed);
+		cache.Set(LiveCacheKey(eventId, stage), (IReadOnlyCollection<PandaScoreMatch>)live);
 	}
 
 	private static string CacheKey(string eventId, Stages stage) => $"PANDASCORE_{eventId}_{stage}";
+	private static string LiveCacheKey(string eventId, Stages stage) => $"PANDASCORE_LIVE_{eventId}_{stage}";
 }

--- a/src/PickemsPlanter/Services/PandaScoreResultsService.cs
+++ b/src/PickemsPlanter/Services/PandaScoreResultsService.cs
@@ -9,6 +9,7 @@ namespace PickemsPlanter.Services;
 public interface IPandaScoreResultsService
 {
 	Task<List<SimulatorMatchResult>> GetCompletedMatchesAsync(string eventId, Stages stage);
+	Task<List<SimulatorLiveMatch>> GetLiveMatchesAsync(string eventId, Stages stage);
 }
 
 public partial class PandaScoreResultsService(IPandaScoreResultsCachingService cachingService, ITournamentCachingService tournamentCachingService) : IPandaScoreResultsService
@@ -59,6 +60,41 @@ public partial class PandaScoreResultsService(IPandaScoreResultsCachingService c
 		}
 
 		return [.. results.OrderBy(r => r.Round)];
+	}
+
+	public async Task<List<SimulatorLiveMatch>> GetLiveMatchesAsync(string eventId, Stages stage)
+	{
+		var matches = cachingService.GetLiveMatches(eventId, stage);
+
+		if (matches.Count == 0)
+			return [];
+
+		var teams = await tournamentCachingService.GetTournamentTeamsAsync(eventId);
+
+		var results = new List<SimulatorLiveMatch>();
+
+		foreach (var match in matches)
+		{
+			var opponents = match.Opponents.Select(o => o.Opponent).ToList();
+
+			if (opponents.Count != 2)
+				continue;
+
+			var teamALogo = ResolveLogoFileName(teams, opponents[0].Name);
+			var teamBLogo = ResolveLogoFileName(teams, opponents[1].Name);
+
+			// Unresolved team name — skip rather than guess, same as the completed-matches path.
+			if (teamALogo is null || teamBLogo is null)
+				continue;
+
+			results.Add(new SimulatorLiveMatch
+			{
+				TeamA = teamALogo,
+				TeamB = teamBLogo
+			});
+		}
+
+		return results;
 	}
 
 	private static string? ResolveLogoFileName(IReadOnlyCollection<Team> teams, string? pandaScoreTeamName)

--- a/src/PickemsPlanter/wwwroot/css/site.css
+++ b/src/PickemsPlanter/wwwroot/css/site.css
@@ -45,9 +45,12 @@
 
 /* Applies to .matchup regardless of whether the bracket is embedded (Stage's Bracket
    View, under .bracket-progression) or standalone (/Simulator) — both share this class. */
+/* Inset (negative offset) rather than an outward ring — the swiss-pool-title round
+   label sits almost flush against the first matchup with no margin, so an outward
+   outline overlaps it; an inset ring stays within the matchup's own box regardless. */
 .matchup.live {
     outline: 2px solid var(--live-colour);
-    outline-offset: 2px;
+    outline-offset: -3px;
     animation: matchup-live-pulse 1.6s ease-in-out infinite;
 }
 

--- a/src/PickemsPlanter/wwwroot/css/site.css
+++ b/src/PickemsPlanter/wwwroot/css/site.css
@@ -9,6 +9,7 @@
     --advance-colour: #5e8b4b;
     --delete-colour: #a85555;
     --disabled-colour: #3a4050;
+    --live-colour: #e2574b;
     --glass-bg: rgba(22, 27, 36, 0.75);
     --glass-border: rgba(255, 255, 255, 0.07);
     --shadow-s: 0 1px 3px rgba(0,0,0,0.5), 0 1px 2px rgba(0,0,0,0.3);
@@ -40,6 +41,19 @@
 .team-tooltip.show {
     opacity: 1;
     transform: translateY(0);
+}
+
+/* Applies to .matchup regardless of whether the bracket is embedded (Stage's Bracket
+   View, under .bracket-progression) or standalone (/Simulator) — both share this class. */
+.matchup.live {
+    outline: 2px solid var(--live-colour);
+    outline-offset: 2px;
+    animation: matchup-live-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes matchup-live-pulse {
+    0%, 100% { outline-color: rgba(226, 87, 75, 0.9); }
+    50% { outline-color: rgba(226, 87, 75, 0.25); }
 }
 
 body {

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -41,6 +41,57 @@ async function LoadAsync() {
     fillInEmptyMatchupsWithUnknown();
 
     await autoFillFromResultsAsync();
+
+    await highlightLiveMatchesAsync();
+}
+
+async function highlightLiveMatchesAsync() {
+    const url = `/Simulator?handler=LiveMatches&eventId=${bracketEventId}&stage=${bracketStage}`;
+
+    let liveMatches;
+
+    try {
+        const response = await fetch(url);
+
+        if (!response.ok) return;
+
+        liveMatches = await response.json();
+    } catch {
+        return;
+    }
+
+    if (!Array.isArray(liveMatches) || liveMatches.length === 0) return;
+
+    for (const match of liveMatches) {
+        const matchup = findMatchupForTeams(match.teamA, match.teamB);
+
+        if (matchup) matchup.classList.add('live');
+    }
+}
+
+// Same lookup as findUndecidedMatchupTeam (undecided matchup, both teams known), just
+// returning the matchup container itself rather than one team's element.
+function findMatchupForTeams(teamASrc, teamBSrc) {
+    const matchups = document.querySelectorAll('.matchup');
+
+    for (const matchup of matchups) {
+        const teamEls = [...matchup.querySelectorAll('.matchup-team')];
+
+        if (teamEls.length !== 2) continue;
+        if (teamEls.some(t => t.classList.contains('advanced') || t.classList.contains('eliminated'))) continue;
+
+        const imgs = teamEls.map(t => t.querySelector('img'));
+
+        if (imgs.some(i => !i)) continue;
+
+        const srcs = imgs.map(i => i.src.split('/').pop());
+
+        if (srcs.includes(teamASrc) && srcs.includes(teamBSrc)) {
+            return matchup;
+        }
+    }
+
+    return null;
 }
 
 async function autoFillFromResultsAsync() {

--- a/tests/PickemsPlanter.Tests/Services/PandaScoreResultsCachingServiceTests.cs
+++ b/tests/PickemsPlanter.Tests/Services/PandaScoreResultsCachingServiceTests.cs
@@ -37,6 +37,19 @@ public class PandaScoreResultsCachingServiceTests
 		]
 	};
 
+	private static PandaScoreMatch RunningMatch(int id) => new()
+	{
+		Id = id,
+		Name = "Round 1: A vs B",
+		Status = "running",
+		WinnerId = null,
+		Opponents =
+		[
+			new() { Opponent = new PandaScoreTeam { Id = 1, Name = "A" } },
+			new() { Opponent = new PandaScoreTeam { Id = 2, Name = "B" } }
+		]
+	};
+
 	[Fact]
 	public async Task RefreshAllAsync_CachesCompletedMatches_ForMappedStages()
 	{
@@ -157,6 +170,51 @@ public class PandaScoreResultsCachingServiceTests
 	{
 		// Act
 		var result = _service.GetCompletedMatches("25", Stages.Stage1);
+
+		// Assert
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public async Task RefreshAllAsync_CachesRunningMatches_SeparatelyFromCompleted()
+	{
+		// Arrange
+		Event @event = new() { Id = "25", Name = "Event 1", Disabled = false, PandaScoreStage1TournamentId = 20708 };
+
+		_eventTableService.GetAllEventsAsync().Returns([@event]);
+
+		List<PandaScoreMatch> matches =
+		[
+			FinishedMatch(1, winnerId: 1),
+			RunningMatch(2),
+			new()
+			{
+				Id = 3,
+				Name = "Round 2: E vs F",
+				Status = "not_started",
+				WinnerId = null,
+				Opponents = []
+			}
+		];
+
+		_pandaScoreApi.GetTournamentMatchesAsync(20708).Returns(matches);
+
+		// Act
+		await _service.RefreshAllAsync();
+
+		// Assert
+		var completed = Assert.Single(_service.GetCompletedMatches(@event.Id, Stages.Stage1));
+		Assert.Equal(1, completed.Id);
+
+		var live = Assert.Single(_service.GetLiveMatches(@event.Id, Stages.Stage1));
+		Assert.Equal(2, live.Id);
+	}
+
+	[Fact]
+	public void GetLiveMatches_ReturnsEmpty_WhenNothingCached()
+	{
+		// Act
+		var result = _service.GetLiveMatches("25", Stages.Stage1);
 
 		// Assert
 		Assert.Empty(result);

--- a/tests/PickemsPlanter.Tests/Services/PandaScoreResultsServiceTests.cs
+++ b/tests/PickemsPlanter.Tests/Services/PandaScoreResultsServiceTests.cs
@@ -309,4 +309,94 @@ public class PandaScoreResultsServiceTests
 		// Assert
 		Assert.Empty(result);
 	}
+
+	[Fact]
+	public async Task GetLiveMatchesAsync_ReturnsEmpty_WhenNoCachedMatches()
+	{
+		// Arrange
+		string eventId = "25";
+		Stages stage = Stages.Stage1;
+
+		_cachingService.GetLiveMatches(eventId, stage).Returns([]);
+
+		// Act
+		var result = await _service.GetLiveMatchesAsync(eventId, stage);
+
+		// Assert
+		Assert.Empty(result);
+		await _tournamentCachingService.DidNotReceive().GetTournamentTeamsAsync(eventId);
+	}
+
+	[Fact]
+	public async Task GetLiveMatchesAsync_ResolvesBothTeamsToLogoFileNames()
+	{
+		// Arrange
+		string eventId = "25";
+		Stages stage = Stages.Stage1;
+
+		List<Team> teams =
+		[
+			new() { Name = "BIG", Logo = "big" },
+			new() { Name = "NRG", Logo = "nrg" }
+		];
+
+		PandaScoreMatch match = new()
+		{
+			Id = 1,
+			Name = "Round 5: NRG vs BIG",
+			Status = "running",
+			WinnerId = null,
+			Opponents =
+			[
+				new() { Opponent = new PandaScoreTeam { Id = 3256, Name = "NRG" } },
+				new() { Opponent = new PandaScoreTeam { Id = 3249, Name = "BIG" } }
+			]
+		};
+
+		_cachingService.GetLiveMatches(eventId, stage).Returns([match]);
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(teams);
+
+		// Act
+		var result = await _service.GetLiveMatchesAsync(eventId, stage);
+
+		// Assert
+		var single = Assert.Single(result);
+		Assert.Equal("nrg.png", single.TeamA);
+		Assert.Equal("big.png", single.TeamB);
+	}
+
+	[Fact]
+	public async Task GetLiveMatchesAsync_SkipsMatch_WhenTeamNameUnresolved()
+	{
+		// Arrange
+		string eventId = "25";
+		Stages stage = Stages.Stage1;
+
+		List<Team> teams =
+		[
+			new() { Name = "BIG", Logo = "big" }
+		];
+
+		PandaScoreMatch match = new()
+		{
+			Id = 1,
+			Name = "Round 1: BIG vs Unknown Team",
+			Status = "running",
+			WinnerId = null,
+			Opponents =
+			[
+				new() { Opponent = new PandaScoreTeam { Id = 3249, Name = "BIG" } },
+				new() { Opponent = new PandaScoreTeam { Id = 9999, Name = "Unknown Team" } }
+			]
+		};
+
+		_cachingService.GetLiveMatches(eventId, stage).Returns([match]);
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(teams);
+
+		// Act
+		var result = await _service.GetLiveMatchesAsync(eventId, stage);
+
+		// Assert
+		Assert.Empty(result);
+	}
 }


### PR DESCRIPTION
## Summary
- Closes #133. Matches currently in progress (per PandaScore) are now visually highlighted in Bracket View, so users can see at a glance which match to watch.
- `PandaScoreResultsCachingService` previously discarded any match that wasn't `status == "finished"` — running matches never made it into the cache. They're now cached separately (`GetLiveMatches`).
- `PandaScoreResultsService.GetLiveMatchesAsync` resolves both opponents to team logo filenames (same fuzzy name-matching already used for completed matches) into a new `SimulatorLiveMatch` model, exposed via a new `OnGetLiveMatches` handler on the `/Simulator` page (shared by both the standalone Simulator and Stage's embedded Bracket View).
- `simulator.js` fetches live matches once per bracket load and matches them to their `.matchup` element the same way completed-result auto-fill already finds undecided matchups; matched matchups get a pulsing outline (`.matchup.live` in `site.css`).
- Follow-up fix: the outline is inset (`outline-offset: -3px`) rather than expanding outward, since the round label above the first matchup in each pool sits almost flush against it with no margin — an outward ring overlapped the label.

## Test plan
- [x] `dotnet test src/PickemsPlanter.sln` — 60/60 passing, including new coverage for the live-match caching split and name resolution.
- [x] Verified the highlight styling visually (`document.querySelector('.matchup').classList.add('live')` in the browser console, since no real match was live at review time).
- [ ] Once a real match goes live for a mapped event/stage, confirm the correct matchup highlights in Bracket View.