### PR TITLE
Show per-team series score inline in Bracket View

### DIFF
--- a/src/PickemsPlanter/Models/PandaScore/PandaScoreMatch.cs
+++ b/src/PickemsPlanter/Models/PandaScore/PandaScoreMatch.cs
@@ -16,6 +16,9 @@ public class PandaScoreMatch
 	[JsonPropertyName("winner_id")]
 	public int? WinnerId { get; init; }
 
+	[JsonPropertyName("number_of_games")]
+	public int NumberOfGames { get; init; }
+
 	public IReadOnlyCollection<PandaScoreOpponent> Opponents { get; init; } = [];
 
 	public IReadOnlyCollection<PandaScoreResult> Results { get; init; } = [];

--- a/src/PickemsPlanter/Models/Simulator/SimulatorMatchResult.cs
+++ b/src/PickemsPlanter/Models/Simulator/SimulatorMatchResult.cs
@@ -11,4 +11,6 @@ public class SimulatorMatchResult
 	// "{winnerScore}-{loserScore}" series score (eg. "2-1" for a BO3), from PandaScore's
 	// per-team Results. Null when Results didn't have a score for both sides.
 	public string? Score { get; init; }
+
+	public required bool IsBestOfThree { get; init; }
 }

--- a/src/PickemsPlanter/Services/PandaScoreResultsService.cs
+++ b/src/PickemsPlanter/Services/PandaScoreResultsService.cs
@@ -55,7 +55,8 @@ public partial class PandaScoreResultsService(IPandaScoreResultsCachingService c
 				WinnerTeam = winnerLogo,
 				LoserTeam = loserLogo,
 				Round = round.Value,
-				Score = ResolveScore(match, winner.Id, loser.Id)
+				Score = ResolveScore(match, winner.Id, loser.Id),
+				IsBestOfThree = match.NumberOfGames == 3
 			});
 		}
 

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -390,22 +390,19 @@
     filter: brightness(40%);
 }
 
-/* Bo3s only (see IsBestOfThree) — score/vs/score are grouped into a single element
-   (.matchup-score-group, built in addMatchupScores) rather than added as separate grid
-   items, so .matchup stays a 3-column grid (team / group / team). Only the middle column
-   widens (16px -> auto, to fit the group) — the team logos keep their normal centered
-   position in the outer 1fr columns, same as every non-Bo3 matchup, instead of being
-   pulled to the inner edge. */
-.bracket-progression .matchup.has-scores {
-    grid-template-columns: 1fr auto 1fr;
-    gap: 10px;
-}
-
+/* Bo3s only (see IsBestOfThree) — .matchup's own grid-template-columns/gap is never
+   touched here, so the team logos' position is guaranteed identical to every non-Bo3
+   matchup. The score/vs/score group is instead an absolutely-positioned overlay, centered
+   on .matchup (which already has position: relative), independent of the grid entirely. */
 .bracket-progression .matchup-score-group {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 14px;
+    gap: 26px;
+    pointer-events: none;
 }
 
 .bracket-progression .matchup-team-score {

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -393,7 +393,10 @@
 /* Bo3s only (see IsBestOfThree) — .matchup's own grid-template-columns/gap is never
    touched here, so the team logos' position is guaranteed identical to every non-Bo3
    matchup. The score/vs/score group is instead an absolutely-positioned overlay, centered
-   on .matchup (which already has position: relative), independent of the grid entirely. */
+   on .matchup (which already has position: relative), independent of the grid entirely.
+   .bracket-progression .swiss-round can be as narrow as 220px (min-width), so this group's
+   total width has to stay well under the ~80px genuinely free between the two 42px logos
+   at that width — kept deliberately compact/small rather than risking overlap again. */
 .bracket-progression .matchup-score-group {
     position: absolute;
     top: 50%;
@@ -401,12 +404,12 @@
     transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
-    gap: 26px;
+    gap: 6px;
     pointer-events: none;
 }
 
 .bracket-progression .matchup-team-score {
-    font-size: 15px;
+    font-size: 12px;
     font-weight: 700;
     color: var(--text-colour);
 }

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -390,24 +390,21 @@
     filter: brightness(40%);
 }
 
-/* Bo3s only (see IsBestOfThree) — adds two more columns either side of the "vs" divider
-   so the layout reads <team-1> <score> vs <score> <team-2>; non-Bo3 matchups keep the
-   plain 3-column grid untouched. The two outer columns are still 1fr (so both scores
-   land equidistant from the vs divider — the columns are equal width), but .matchup-team
-   normally centers itself within that wide column (see the plain .matchup-team rule
-   above) which left the score+vs cluster floating alone in the middle, detached from
-   both logos — pulling each logo to the edge nearest its score fixes that.
-*/
+/* Bo3s only (see IsBestOfThree) — score/vs/score are grouped into a single element
+   (.matchup-score-group, built in addMatchupScores) rather than added as separate grid
+   items, so .matchup stays a 3-column grid (team / group / team). Only the middle column
+   widens (16px -> auto, to fit the group) — the team logos keep their normal centered
+   position in the outer 1fr columns, same as every non-Bo3 matchup, instead of being
+   pulled to the inner edge. */
 .bracket-progression .matchup.has-scores {
-    grid-template-columns: 1fr auto 16px auto 1fr;
+    grid-template-columns: 1fr auto 1fr;
 }
 
-.bracket-progression .matchup.has-scores .matchup-team:first-child {
-    justify-self: end;
-}
-
-.bracket-progression .matchup.has-scores .matchup-team:last-child {
-    justify-self: start;
+.bracket-progression .matchup-score-group {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
 }
 
 .bracket-progression .matchup-team-score {

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -393,10 +393,7 @@
 /* Bo3s only (see IsBestOfThree) — .matchup's own grid-template-columns/gap is never
    touched here, so the team logos' position is guaranteed identical to every non-Bo3
    matchup. The score/vs/score group is instead an absolutely-positioned overlay, centered
-   on .matchup (which already has position: relative), independent of the grid entirely.
-   .bracket-progression .swiss-round can be as narrow as 220px (min-width), so this group's
-   total width has to stay well under the ~80px genuinely free between the two 42px logos
-   at that width — kept deliberately compact/small rather than risking overlap again. */
+   on .matchup (which already has position: relative), independent of the grid entirely. */
 .bracket-progression .matchup-score-group {
     position: absolute;
     top: 50%;
@@ -404,12 +401,12 @@
     transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 26px;
     pointer-events: none;
 }
 
 .bracket-progression .matchup-team-score {
-    font-size: 12px;
+    font-size: 15px;
     font-weight: 700;
     color: var(--text-colour);
 }

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -392,15 +392,28 @@
 
 /* Bo3s only (see IsBestOfThree) — adds two more columns either side of the "vs" divider
    so the layout reads <team-1> <score> vs <score> <team-2>; non-Bo3 matchups keep the
-   plain 3-column grid untouched. */
+   plain 3-column grid untouched. The two outer columns are still 1fr (so both scores
+   land equidistant from the vs divider — the columns are equal width), but .matchup-team
+   normally centers itself within that wide column (see the plain .matchup-team rule
+   above) which left the score+vs cluster floating alone in the middle, detached from
+   both logos — pulling each logo to the edge nearest its score fixes that.
+*/
 .bracket-progression .matchup.has-scores {
     grid-template-columns: 1fr auto 16px auto 1fr;
 }
 
+.bracket-progression .matchup.has-scores .matchup-team:first-child {
+    justify-self: end;
+}
+
+.bracket-progression .matchup.has-scores .matchup-team:last-child {
+    justify-self: start;
+}
+
 .bracket-progression .matchup-team-score {
-    font-size: 11px;
+    font-size: 15px;
     font-weight: 700;
-    color: rgba(232, 234, 240, 0.7);
+    color: var(--text-colour);
 }
 
 .bracket-progression .teams-container {

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -390,19 +390,22 @@
     filter: brightness(40%);
 }
 
-/* Bo3s only (see IsBestOfThree) — .matchup's own grid-template-columns/gap is never
-   touched here, so the team logos' position is guaranteed identical to every non-Bo3
-   matchup. The score/vs/score group is instead an absolutely-positioned overlay, centered
-   on .matchup (which already has position: relative), independent of the grid entirely. */
+/* Bo3s only (see IsBestOfThree) — score/vs/score are grouped into a single element
+   (.matchup-score-group, built in addMatchupScores) rather than added as separate grid
+   items, so .matchup stays a 3-column grid (team / group / team). Only the middle column
+   widens (16px -> auto, to fit the group) — the team logos keep their normal centered
+   position in the outer 1fr columns, same as every non-Bo3 matchup, instead of being
+   pulled to the inner edge. */
+.bracket-progression .matchup.has-scores {
+    grid-template-columns: 1fr auto 1fr;
+    gap: 10px;
+}
+
 .bracket-progression .matchup-score-group {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
-    gap: 26px;
-    pointer-events: none;
+    justify-content: center;
+    gap: 14px;
 }
 
 .bracket-progression .matchup-team-score {

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -390,6 +390,19 @@
     filter: brightness(40%);
 }
 
+/* Bo3s only (see IsBestOfThree) — adds two more columns either side of the "vs" divider
+   so the layout reads <team-1> <score> vs <score> <team-2>; non-Bo3 matchups keep the
+   plain 3-column grid untouched. */
+.bracket-progression .matchup.has-scores {
+    grid-template-columns: 1fr auto 16px auto 1fr;
+}
+
+.bracket-progression .matchup-team-score {
+    font-size: 11px;
+    font-weight: 700;
+    color: rgba(232, 234, 240, 0.7);
+}
+
 .bracket-progression .teams-container {
     flex-direction: row !important;
     justify-content: center;

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -398,13 +398,14 @@
    pulled to the inner edge. */
 .bracket-progression .matchup.has-scores {
     grid-template-columns: 1fr auto 1fr;
+    gap: 10px;
 }
 
 .bracket-progression .matchup-score-group {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 4px;
+    gap: 14px;
 }
 
 .bracket-progression .matchup-team-score {

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -152,6 +152,10 @@ async function autoFillFromResultsAsync() {
 
 // Splits "{winnerScore}-{loserScore}" (eg. "2-1") back out per-team and places each
 // team's own score between its logo and the "vs" divider — <team1> <score> vs <score> <team2>.
+// Wraps score/vs/score in one group rather than adding them as separate top-level grid
+// items — .matchup stays a 3-column grid (team/group/team) so the team logos keep their
+// normal centered position instead of being forced to the inner edge; only the middle
+// column widens (fixed 16px -> auto) to fit the group's content.
 function addMatchupScores(winnerTeam, score) {
     const matchup = winnerTeam.closest('.matchup');
     const vsDivider = matchup?.querySelector('.vs');
@@ -168,9 +172,13 @@ function addMatchupScores(winnerTeam, score) {
     const firstScore = isWinnerFirst ? winnerScore : loserScore;
     const secondScore = isWinnerFirst ? loserScore : winnerScore;
 
+    const group = document.createElement('div');
+    group.className = 'matchup-score-group';
+
+    vsDivider.replaceWith(group);
+    group.append(createMatchupScoreElement(firstScore), vsDivider, createMatchupScoreElement(secondScore));
+
     matchup.classList.add('has-scores');
-    vsDivider.insertAdjacentElement('beforebegin', createMatchupScoreElement(firstScore));
-    vsDivider.insertAdjacentElement('afterend', createMatchupScoreElement(secondScore));
 }
 
 function createMatchupScoreElement(scoreText) {

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -152,10 +152,10 @@ async function autoFillFromResultsAsync() {
 
 // Splits "{winnerScore}-{loserScore}" (eg. "2-1") back out per-team and places each
 // team's own score between its logo and the "vs" divider — <team1> <score> vs <score> <team2>.
-// Wraps score/vs/score in one group rather than adding them as separate top-level grid
-// items — .matchup stays a 3-column grid (team/group/team) so the team logos keep their
-// normal centered position instead of being forced to the inner edge; only the middle
-// column widens (fixed 16px -> auto) to fit the group's content.
+// Wraps score/vs/score in one group and positions that group as an absolutely-positioned
+// overlay (see .matchup-score-group) rather than touching .matchup's own grid — the team
+// logos' position must stay byte-for-byte identical to every non-Bo3 matchup, so nothing
+// here is allowed to change .matchup's grid-template-columns/gap.
 function addMatchupScores(winnerTeam, score) {
     const matchup = winnerTeam.closest('.matchup');
     const vsDivider = matchup?.querySelector('.vs');
@@ -177,8 +177,6 @@ function addMatchupScores(winnerTeam, score) {
 
     vsDivider.replaceWith(group);
     group.append(createMatchupScoreElement(firstScore), vsDivider, createMatchupScoreElement(secondScore));
-
-    matchup.classList.add('has-scores');
 }
 
 function createMatchupScoreElement(scoreText) {

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -139,12 +139,46 @@ async function autoFillFromResultsAsync() {
             if (winnerTeam) {
                 selectTeam(winnerTeam);
 
-                // match.score (from SimulatorMatchResult/PandaScoreResultsService) is still
-                // fetched here — just not rendered. Kept available for whatever reads
-                // autoFillFromResultsAsync's match data next.
+                // Score display is a Bracket View (/PickEms/Stage) feature only — /Simulator
+                // stays exactly as it was before scores were added. Only Bo3s (not Bo1s) get
+                // a score at all — see SimulatorMatchResult.IsBestOfThree.
+                if (match.isBestOfThree && match.score && window.bracketViewReadOnly) {
+                    addMatchupScores(winnerTeam, match.score);
+                }
             }
         }
     }
+}
+
+// Splits "{winnerScore}-{loserScore}" (eg. "2-1") back out per-team and places each
+// team's own score between its logo and the "vs" divider — <team1> <score> vs <score> <team2>.
+function addMatchupScores(winnerTeam, score) {
+    const matchup = winnerTeam.closest('.matchup');
+    const vsDivider = matchup?.querySelector('.vs');
+
+    if (!matchup || !vsDivider) return;
+
+    const teamEls = [...matchup.querySelectorAll('.matchup-team')];
+    const loserTeam = teamEls.find(t => t !== winnerTeam);
+
+    if (!loserTeam) return;
+
+    const [winnerScore, loserScore] = score.split('-');
+    const isWinnerFirst = teamEls[0] === winnerTeam;
+    const firstScore = isWinnerFirst ? winnerScore : loserScore;
+    const secondScore = isWinnerFirst ? loserScore : winnerScore;
+
+    matchup.classList.add('has-scores');
+    vsDivider.insertAdjacentElement('beforebegin', createMatchupScoreElement(firstScore));
+    vsDivider.insertAdjacentElement('afterend', createMatchupScoreElement(secondScore));
+}
+
+function createMatchupScoreElement(scoreText) {
+    const scoreElement = document.createElement('div');
+    scoreElement.className = 'matchup-team-score';
+    scoreElement.textContent = scoreText;
+
+    return scoreElement;
 }
 
 function findUndecidedMatchupTeam(winnerSrc, loserSrc) {

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -152,10 +152,10 @@ async function autoFillFromResultsAsync() {
 
 // Splits "{winnerScore}-{loserScore}" (eg. "2-1") back out per-team and places each
 // team's own score between its logo and the "vs" divider — <team1> <score> vs <score> <team2>.
-// Wraps score/vs/score in one group and positions that group as an absolutely-positioned
-// overlay (see .matchup-score-group) rather than touching .matchup's own grid — the team
-// logos' position must stay byte-for-byte identical to every non-Bo3 matchup, so nothing
-// here is allowed to change .matchup's grid-template-columns/gap.
+// Wraps score/vs/score in one group rather than adding them as separate top-level grid
+// items — .matchup stays a 3-column grid (team/group/team) so the team logos keep their
+// normal centered position instead of being forced to the inner edge; only the middle
+// column widens (fixed 16px -> auto) to fit the group's content.
 function addMatchupScores(winnerTeam, score) {
     const matchup = winnerTeam.closest('.matchup');
     const vsDivider = matchup?.querySelector('.vs');
@@ -177,6 +177,8 @@ function addMatchupScores(winnerTeam, score) {
 
     vsDivider.replaceWith(group);
     group.append(createMatchupScoreElement(firstScore), vsDivider, createMatchupScoreElement(secondScore));
+
+    matchup.classList.add('has-scores');
 }
 
 function createMatchupScoreElement(scoreText) {

--- a/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
+++ b/src/PickemsPlanter/wwwroot/js/Simulator/simulator.js
@@ -140,9 +140,11 @@ async function autoFillFromResultsAsync() {
                 selectTeam(winnerTeam);
 
                 // Score display is a Bracket View (/PickEms/Stage) feature only — /Simulator
-                // stays exactly as it was before scores were added. Only Bo3s (not Bo1s) get
-                // a score at all — see SimulatorMatchResult.IsBestOfThree.
-                if (match.isBestOfThree && match.score && window.bracketViewReadOnly) {
+                // stays exactly as it was before scores were added. Shown for every decided
+                // match (not just Bo3s) — restricting it to Bo3 only meant some decided
+                // matchups got the wider score layout and others didn't, which read as an
+                // inconsistent/broken grid rather than a deliberate difference.
+                if (match.score && window.bracketViewReadOnly) {
                     addMatchupScores(winnerTeam, match.score);
                 }
             }

--- a/tests/PickemsPlanter.Tests/Services/PandaScoreResultsServiceTests.cs
+++ b/tests/PickemsPlanter.Tests/Services/PandaScoreResultsServiceTests.cs
@@ -53,6 +53,7 @@ public class PandaScoreResultsServiceTests
 			Name = "Round 5: NRG vs BIG",
 			Status = "finished",
 			WinnerId = 3249,
+			NumberOfGames = 3,
 			Opponents =
 			[
 				new() { Opponent = new PandaScoreTeam { Id = 3256, Name = "NRG" } },
@@ -77,6 +78,50 @@ public class PandaScoreResultsServiceTests
 		Assert.Equal("nrg.png", single.LoserTeam);
 		Assert.Equal(5, single.Round);
 		Assert.Equal("2-1", single.Score);
+		Assert.True(single.IsBestOfThree);
+	}
+
+	[Fact]
+	public async Task GetCompletedMatchesAsync_IsBestOfThree_IsFalse_WhenMatchIsBestOfOne()
+	{
+		// Arrange
+		string eventId = "25";
+		Stages stage = Stages.Stage1;
+
+		List<Team> teams =
+		[
+			new() { Name = "BIG", Logo = "big" },
+			new() { Name = "NRG", Logo = "nrg" }
+		];
+
+		PandaScoreMatch match = new()
+		{
+			Id = 1,
+			Name = "Round 1: NRG vs BIG",
+			Status = "finished",
+			WinnerId = 3249,
+			NumberOfGames = 1,
+			Opponents =
+			[
+				new() { Opponent = new PandaScoreTeam { Id = 3256, Name = "NRG" } },
+				new() { Opponent = new PandaScoreTeam { Id = 3249, Name = "BIG" } }
+			],
+			Results =
+			[
+				new() { TeamId = 3256, Score = 0 },
+				new() { TeamId = 3249, Score = 1 }
+			]
+		};
+
+		_cachingService.GetCompletedMatches(eventId, stage).Returns([match]);
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(teams);
+
+		// Act
+		var result = await _service.GetCompletedMatchesAsync(eventId, stage);
+
+		// Assert
+		var single = Assert.Single(result);
+		Assert.False(single.IsBestOfThree);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary
- Closes #134 (redefined scope — see the issue for why the original click-for-map-details plan was dropped after checking PandaScore's actual API response).
- Shows the existing series score (eg. "2-1") inline in Bracket View, split per-team and positioned beside each logo, framing the "vs" divider: `<team-1-img> <score> vs <score> <team-2-img>`.
- Shown for every decided matchup (not just Bo3s) — an earlier iteration restricted it to Bo3-only, but that made some decided matchups use a wider grid than others, which read as an inconsistent/broken layout rather than a deliberate difference. Showing it uniformly for every decided match fixed that.
- `PandaScoreMatch.NumberOfGames` / `SimulatorMatchResult.IsBestOfThree` are still wired up (from PandaScore's `number_of_games`) but currently unused for the display gate — kept rather than ripped out mid-iteration, same "keep the data, don't render it" pattern this codebase already used once before.
- Bracket View (`/PickEms/Stage`) only, same scoping the original (now-removed) score display had — not the standalone `/Simulator` page.

## Test plan
- [x] `dotnet test src/PickemsPlanter.sln` passing.
- [x] Visually verified in Bracket View against real completed matches — went through several rounds of layout fixes (score detachment, team logos shifting position, overflow/overlap with the logos) before landing on the current grouped-group + widened-middle-column approach.
- [ ] Spot check on a narrow viewport / with many round columns visible at once, since the bracket's round columns can be as narrow as 220px.