### PR TITLE
Fix terminal bracket-pool teams looking interactive in Bracket View

### DIFF
--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -473,14 +473,25 @@
     display: none;
 }
 
-/* #2-3/#1-3 (above) stay visible rather than hidden, but they're still just a display-only
-   bracket slot — getTeamSourceElements() already excludes anything inside #bracketProgression
-   from drag activation (see utilities.js), so nothing here is actually draggable. Without this,
-   they inherit cursor:grab from the plain .team rule meant for Simple View's draggable source
-   cards, which visually implies they're interactive when they aren't. */
-.bracket-progression [id="2-3"] > .team,
-.bracket-progression [id="1-3"] > .team {
+/* #2-3/#1-3 (above) stay visible rather than hidden, but every terminal pool's .team is
+   still just a display-only bracket slot — getTeamSourceElements() already excludes anything
+   inside #bracketProgression from drag activation (see utilities.js), so nothing here is
+   actually draggable. Without this, they inherit interactive-looking styling meant for Simple
+   View's draggable source cards: cursor:grab from the plain .team rule (below), and a hover
+   scale + blue box-shadow ring from stagePlayoffs.css's .team:not([disabled]):hover — these
+   elements never get [disabled] (only Simple View's cards do), so that rule always matches.
+   Scoped to .teams-container generally (not just #2-3/#1-3) so it can't be missed again for
+   whichever terminal pool happens to be visible. */
+.bracket-progression .teams-container .team {
     cursor: default;
+}
+
+.bracket-progression .teams-container .team:hover {
+    box-shadow: var(--shadow-s);
+}
+
+.bracket-progression .teams-container .team:hover .team-img {
+    transform: none;
 }
 
 

--- a/src/PickemsPlanter/wwwroot/css/stage.css
+++ b/src/PickemsPlanter/wwwroot/css/stage.css
@@ -473,6 +473,16 @@
     display: none;
 }
 
+/* #2-3/#1-3 (above) stay visible rather than hidden, but they're still just a display-only
+   bracket slot — getTeamSourceElements() already excludes anything inside #bracketProgression
+   from drag activation (see utilities.js), so nothing here is actually draggable. Without this,
+   they inherit cursor:grab from the plain .team rule meant for Simple View's draggable source
+   cards, which visually implies they're interactive when they aren't. */
+.bracket-progression [id="2-3"] > .team,
+.bracket-progression [id="1-3"] > .team {
+    cursor: default;
+}
+
 
 /* ── DROPZONES ── */
 .dropzone-advanced,


### PR DESCRIPTION
## Summary
- Closes #142. In Bracket View, teams sitting in the terminal `2-3`/`1-3` (eliminated) pools showed a grab cursor and a hover scale + blue box-shadow ring, looking like active/draggable teams. They aren't — these are display-only bracket slots.
- Root cause: all six terminal pools (`3-0`/`3-1`/`3-2`/`0-3`/`2-3`/`1-3`) reuse the `.team` class, which is also used by Simple View's draggable source cards. Four of the six already had a CSS override hiding them entirely (they duplicate the pick0-9 dropzones for Buchholz bookkeeping), which incidentally hid the stray interactive styling too — `2-3`/`1-3` are intentionally left visible but never got an equivalent override.
- `getTeamSourceElements()` already excludes anything inside `#bracketProgression` from actual drag activation, so this was purely a misleading visual cue, not broken functionality.
- Fix is scoped generally (`.bracket-progression .teams-container .team`) rather than hardcoded to specific pool ids, so it can't be missed again for whichever terminal pool happens to be visible.

## Test plan
- [x] `dotnet test src/PickemsPlanter.sln` passing.
- [x] Visually verified in Bracket View — cursor, hover scale, and hover box-shadow ring no longer trigger on `2-3`/`1-3` teams.