### PR TITLE
Fix inconsistent team tooltip vertical position

### DIFF
--- a/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
+++ b/src/PickemsPlanter/wwwroot/js/PickEms/stylingFunctions.js
@@ -14,6 +14,17 @@ function isTeamImageElement(element) {
         && (element.classList.contains('team-img') || element.classList.contains('dropped-img'));
 }
 
+// team-img/dropped-img are sized by object-fit:contain with only min/max constraints, so
+// their rendered box shrinks to the hovered logo's own aspect ratio (e.g. a wide wordmark
+// logo renders far shorter than a square crest) rather than matching the fixed-size slot
+// (.team/.matchup-team/.dropzone-advanced/.dropzone-eliminated) it visually sits in. Anchor
+// the tooltip to that stable slot instead of the image so its vertical offset from the
+// slot's edge — what a user actually perceives as "the team's box" — stays consistent
+// regardless of which logo happens to be in it.
+function resolveTooltipAnchor(target) {
+    return target.closest('.team, .matchup-team, .dropzone-advanced, .dropzone-eliminated') ?? target;
+}
+
 function ensureTeamTooltipElement() {
     if (!teamTooltipElement) {
         teamTooltipElement = document.createElement('div');
@@ -43,7 +54,7 @@ document.addEventListener('mouseover', (event) => {
 
     const tooltip = ensureTeamTooltipElement();
     tooltip.textContent = resolveTeamTitle(event.target.src);
-    positionTeamTooltip(tooltip, event.target);
+    positionTeamTooltip(tooltip, resolveTooltipAnchor(event.target));
     tooltip.classList.add('show');
 });
 


### PR DESCRIPTION
## Summary
- `positionTeamTooltip` anchored to the hovered `<img>` (`team-img`/`dropped-img`) rather than its slot container. Those images use `object-fit: contain` with only min/max constraints, so their rendered box shrinks to match the logo's own aspect ratio (a wide wordmark logo renders much shorter than a square crest) instead of the fixed `.team`/`.matchup-team`/`.dropzone-advanced`/`.dropzone-eliminated` slot it visually sits in.
- Verified with a local Playwright harness against the real CSS/JS: two logos in an identically-sized dropzone could produce tooltip positions ~19px apart. Anchoring to the stable slot element instead of the image brings that down to <1px and keeps the gap a consistent 8px across Bracket View, Simple View, and Simulator.
- The existing above/below flip near the viewport edge is unaffected.

Fixes #145

## Test plan
- [x] `dotnet test src/PickemsPlanter.sln` — 82/82 passing (no existing coverage for frontend JS)
- [x] Local Playwright harness confirming tooltip gap consistency before/after fix across Bracket View, Simple View, Simulator, and varying logo aspect ratios