### PR TITLE
Automate advancing-8 seed derivation for Stage 2/3

### DIFF
--- a/src/PickemsPlanter/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PickemsPlanter/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,8 @@ public static class ServiceCollectionExtensions
 			services.AddSingleton<ISeedsService, SeedsService>();
 			services.AddSingleton<IPandaScoreResultsService, PandaScoreResultsService>();
 			services.AddSingleton<ICoinProgressService, CoinProgressService>();
+			services.AddSingleton<ISwissStandingsCalculator, SwissStandingsCalculator>();
+			services.AddSingleton<IAdvancingSeedAutomationService, AdvancingSeedAutomationService>();
 			services.AddOptions<SteamConfig>().Bind(config.GetSection(nameof(SteamConfig)));
 			services.AddOptions<PandaScoreConfig>().Bind(config.GetSection(nameof(PandaScoreConfig)));
 			services.AddOptions<EventDiscoveryConfig>().Bind(config.GetSection(nameof(EventDiscoveryConfig)));

--- a/src/PickemsPlanter/Services/AdvancingSeedAutomationService.cs
+++ b/src/PickemsPlanter/Services/AdvancingSeedAutomationService.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging;
+using PickemsPlanter.Models.Event;
+using PickemsPlanter.Models.Simulator;
+
+namespace PickemsPlanter.Services;
+
+public interface IAdvancingSeedAutomationService
+{
+	Task ApplyAdvancingSeedsAsync(string eventId, Stages stage, IReadOnlyCollection<SimulatorMatchResult> completedMatches);
+}
+
+// Per Valve's Major Supplemental Rulebook, a Stage 2/3 bracket's 16 teams are always seeds
+// 1-8 (pre-qualified invites, entered manually — see issue #147) plus seeds 9-16 (the
+// previous stage's advancing 8, ordered by that stage's own record/Buchholz/seed tiebreak).
+// This service derives the second half automatically once a stage fully resolves, and
+// auto-applies it (no confirmation step — see issue #138) so seeding for the next stage
+// never has to be typed in by hand.
+//
+// Takes the mapped completed-match list as a parameter rather than depending on
+// IPandaScoreResultsService, since that service depends on IPandaScoreResultsCachingService —
+// the same singleton that drives this automation — and injecting it here would create a
+// circular DI dependency.
+public class AdvancingSeedAutomationService(
+	ISeedsTableService seedsTableService,
+	ITournamentCachingService tournamentCachingService,
+	ISwissStandingsCalculator standingsCalculator,
+	ILogger<AdvancingSeedAutomationService> logger) : IAdvancingSeedAutomationService
+{
+	public async Task ApplyAdvancingSeedsAsync(string eventId, Stages stage, IReadOnlyCollection<SimulatorMatchResult> completedMatches)
+	{
+		Stages? nextStage = stage switch
+		{
+			Stages.Stage1 => Stages.Stage2,
+			Stages.Stage2 => Stages.Stage3,
+			_ => null
+		};
+
+		if (nextStage is null || completedMatches.Count == 0)
+			return;
+
+		var currentSeeds = await seedsTableService.GetSeedsInStageAsync(stage, eventId);
+
+		// This stage's own seeding (the initial-seed tiebreak input) isn't fully entered
+		// yet — nothing reliable to compute standings against.
+		if (currentSeeds.Count != 16)
+			return;
+
+		var teams = await tournamentCachingService.GetTournamentTeamsAsync(eventId);
+
+		Dictionary<string, int> initialSeedByLogo = [];
+
+		foreach (var seed in currentSeeds)
+		{
+			var team = teams.FirstOrDefault(t => t.Name!.Equals(seed.RowKey, StringComparison.CurrentCultureIgnoreCase));
+
+			// Can't map every seeded team to a logo — bail rather than compute a partial/incorrect standing.
+			if (team?.Logo is null)
+				return;
+
+			initialSeedByLogo[$"{team.Logo}.png"] = seed.Rank;
+		}
+
+		if (!standingsCalculator.TryCalculateFinalStandings(completedMatches, initialSeedByLogo, out var standings))
+			return;
+
+		var advancing = standings.Where(s => s.Wins == 3).ToList();
+
+		if (advancing.Count != 8)
+			return;
+
+		Dictionary<string, int> seedsByTeamName = [];
+
+		for (int i = 0; i < advancing.Count; i++)
+		{
+			var team = teams.FirstOrDefault(t => $"{t.Logo}.png" == advancing[i].Team);
+
+			if (team?.Name is null)
+				return;
+
+			seedsByTeamName[team.Name] = 9 + i;
+		}
+
+		await seedsTableService.UpsertSeedsAsync(nextStage.Value, eventId, seedsByTeamName);
+
+		logger.LogInformation("Auto-applied advancing seeds for event {EventId}: {Stage} -> {NextStage}", eventId, stage, nextStage);
+	}
+}

--- a/src/PickemsPlanter/Services/PandaScoreMatchMapper.cs
+++ b/src/PickemsPlanter/Services/PandaScoreMatchMapper.cs
@@ -1,0 +1,118 @@
+using PickemsPlanter.Models.PandaScore;
+using PickemsPlanter.Models.Simulator;
+using PickemsPlanter.Models.Steam;
+using System.Text.RegularExpressions;
+
+namespace PickemsPlanter.Services;
+
+// Shared PandaScore -> Steam team-name resolution and match mapping, used by both
+// PandaScoreResultsService and AdvancingSeedAutomationService. Kept out of
+// PandaScoreResultsService so callers that only need the mapping don't have to take a
+// dependency on IPandaScoreResultsService (which itself depends on
+// IPandaScoreResultsCachingService — a cycle for callers invoked from inside that caching service).
+public static partial class PandaScoreMatchMapper
+{
+	public static List<SimulatorMatchResult> ToCompletedMatchResults(IReadOnlyCollection<PandaScoreMatch> matches, IReadOnlyCollection<Team> teams)
+	{
+		var results = new List<SimulatorMatchResult>();
+
+		foreach (var match in matches)
+		{
+			int? round = ParseRound(match.Name);
+
+			if (round is null)
+				continue;
+
+			var opponents = match.Opponents.Select(o => o.Opponent).ToList();
+
+			if (opponents.Count != 2)
+				continue;
+
+			var winner = opponents.FirstOrDefault(o => o.Id == match.WinnerId);
+			var loser = opponents.FirstOrDefault(o => o.Id != match.WinnerId);
+
+			if (winner is null || loser is null)
+				continue;
+
+			var winnerLogo = ResolveLogoFileName(teams, winner.Name);
+			var loserLogo = ResolveLogoFileName(teams, loser.Name);
+
+			// Unresolved team name — skip rather than guess, leave that matchup fully manual.
+			if (winnerLogo is null || loserLogo is null)
+				continue;
+
+			results.Add(new SimulatorMatchResult
+			{
+				WinnerTeam = winnerLogo,
+				LoserTeam = loserLogo,
+				Round = round.Value,
+				Score = ResolveScore(match, winner.Id, loser.Id),
+				IsBestOfThree = match.NumberOfGames == 3
+			});
+		}
+
+		return [.. results.OrderBy(r => r.Round)];
+	}
+
+	public static string? ResolveLogoFileName(IReadOnlyCollection<Team> teams, string? pandaScoreTeamName)
+	{
+		if (pandaScoreTeamName is null)
+			return null;
+
+		var exactMatches = teams.Where(x => x.Name!.Equals(pandaScoreTeamName, StringComparison.CurrentCultureIgnoreCase)).ToList();
+
+		if (exactMatches.Count == 1)
+			return $"{exactMatches[0].Logo}.png";
+
+		// PandaScore and Steam sometimes use slightly different variants of the same org's name
+		// (eg. "Liquid" vs "Team Liquid", "BetBoom Team" vs "BetBoom") — fall back to a
+		// normalized substring match, but only commit when it resolves to exactly one candidate.
+		string normalizedPandaScoreName = Normalize(pandaScoreTeamName);
+
+		var fuzzyMatches = teams
+			.Where(x =>
+			{
+				string normalizedTeamName = Normalize(x.Name!);
+
+				if (normalizedTeamName == normalizedPandaScoreName
+					|| normalizedTeamName.Contains(normalizedPandaScoreName)
+					|| normalizedPandaScoreName.Contains(normalizedTeamName))
+					return true;
+
+				// Some orgs are commonly referred to by an initialism of their full name
+				// (eg. "NiP" for "Ninjas in Pyjamas") — the initials aren't a contiguous
+				// substring of the space-stripped name, so the checks above miss it.
+				return GetInitials(x.Name!) == normalizedPandaScoreName
+					|| GetInitials(pandaScoreTeamName) == normalizedTeamName;
+			})
+			.ToList();
+
+		return fuzzyMatches.Count == 1 ? $"{fuzzyMatches[0].Logo}.png" : null;
+	}
+
+	private static string? ResolveScore(PandaScoreMatch match, int winnerId, int loserId)
+	{
+		var winnerResult = match.Results.FirstOrDefault(r => r.TeamId == winnerId);
+		var loserResult = match.Results.FirstOrDefault(r => r.TeamId == loserId);
+
+		return winnerResult is not null && loserResult is not null
+			? $"{winnerResult.Score}-{loserResult.Score}"
+			: null;
+	}
+
+	private static string Normalize(string name) =>
+		string.Concat(name.Where(char.IsLetterOrDigit)).ToLowerInvariant();
+
+	private static string GetInitials(string name) =>
+		string.Concat(name.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(word => word[0])).ToLowerInvariant();
+
+	private static int? ParseRound(string matchName)
+	{
+		var match = RoundNumberRegex().Match(matchName);
+
+		return match.Success ? int.Parse(match.Groups[1].Value) : null;
+	}
+
+	[GeneratedRegex(@"^Round (\d+):", RegexOptions.IgnoreCase)]
+	private static partial Regex RoundNumberRegex();
+}

--- a/src/PickemsPlanter/Services/PandaScoreResultsCachingService.cs
+++ b/src/PickemsPlanter/Services/PandaScoreResultsCachingService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PickemsPlanter.APIs;
 using PickemsPlanter.Models.Configurations;
@@ -16,8 +17,11 @@ public interface IPandaScoreResultsCachingService
 public class PandaScoreResultsCachingService(
 	IPandaScoreApi pandaScoreApi,
 	IEventTableService eventTableService,
+	ITournamentCachingService tournamentCachingService,
+	IAdvancingSeedAutomationService advancingSeedAutomationService,
 	IMemoryCache cache,
-	IOptionsMonitor<PandaScoreConfig> config) : IHostedService, IPandaScoreResultsCachingService
+	IOptionsMonitor<PandaScoreConfig> config,
+	ILogger<PandaScoreResultsCachingService> logger) : IHostedService, IPandaScoreResultsCachingService
 {
 	private readonly PandaScoreConfig _config = config.CurrentValue;
 	private CancellationTokenSource? _cts;
@@ -117,6 +121,25 @@ public class PandaScoreResultsCachingService(
 
 		cache.Set(CacheKey(eventId, stage), (IReadOnlyCollection<PandaScoreMatch>)completed);
 		cache.Set(LiveCacheKey(eventId, stage), (IReadOnlyCollection<PandaScoreMatch>)live);
+
+		// Stage3/Playoffs have no "next stage" advancing-seed automation (see AdvancingSeedAutomationService);
+		// skip the extra team lookup entirely rather than let it no-op deeper in the call.
+		if (stage is not (Stages.Stage1 or Stages.Stage2))
+			return;
+
+		try
+		{
+			var teams = await tournamentCachingService.GetTournamentTeamsAsync(eventId);
+			var results = PandaScoreMatchMapper.ToCompletedMatchResults(completed, teams);
+
+			await advancingSeedAutomationService.ApplyAdvancingSeedsAsync(eventId, stage, results);
+		}
+		catch (Exception ex)
+		{
+			// Advancing-seed automation must never break the poll loop or the match cache it just wrote —
+			// same fail-soft principle as the rest of the PandaScore integration.
+			logger.LogWarning(ex, "Advancing-seed automation failed for event {EventId} stage {Stage}", eventId, stage);
+		}
 	}
 
 	private static string CacheKey(string eventId, Stages stage) => $"PANDASCORE_{eventId}_{stage}";

--- a/src/PickemsPlanter/Services/PandaScoreResultsService.cs
+++ b/src/PickemsPlanter/Services/PandaScoreResultsService.cs
@@ -1,8 +1,5 @@
 using PickemsPlanter.Models.Event;
-using PickemsPlanter.Models.PandaScore;
 using PickemsPlanter.Models.Simulator;
-using PickemsPlanter.Models.Steam;
-using System.Text.RegularExpressions;
 
 namespace PickemsPlanter.Services;
 
@@ -12,7 +9,7 @@ public interface IPandaScoreResultsService
 	Task<List<SimulatorLiveMatch>> GetLiveMatchesAsync(string eventId, Stages stage);
 }
 
-public partial class PandaScoreResultsService(IPandaScoreResultsCachingService cachingService, ITournamentCachingService tournamentCachingService) : IPandaScoreResultsService
+public class PandaScoreResultsService(IPandaScoreResultsCachingService cachingService, ITournamentCachingService tournamentCachingService) : IPandaScoreResultsService
 {
 	public async Task<List<SimulatorMatchResult>> GetCompletedMatchesAsync(string eventId, Stages stage)
 	{
@@ -23,44 +20,7 @@ public partial class PandaScoreResultsService(IPandaScoreResultsCachingService c
 
 		var teams = await tournamentCachingService.GetTournamentTeamsAsync(eventId);
 
-		var results = new List<SimulatorMatchResult>();
-
-		foreach (var match in matches)
-		{
-			int? round = ParseRound(match.Name);
-
-			if (round is null)
-				continue;
-
-			var opponents = match.Opponents.Select(o => o.Opponent).ToList();
-
-			if (opponents.Count != 2)
-				continue;
-
-			var winner = opponents.FirstOrDefault(o => o.Id == match.WinnerId);
-			var loser = opponents.FirstOrDefault(o => o.Id != match.WinnerId);
-
-			if (winner is null || loser is null)
-				continue;
-
-			var winnerLogo = ResolveLogoFileName(teams, winner.Name);
-			var loserLogo = ResolveLogoFileName(teams, loser.Name);
-
-			// Unresolved team name — skip rather than guess, leave that matchup fully manual.
-			if (winnerLogo is null || loserLogo is null)
-				continue;
-
-			results.Add(new SimulatorMatchResult
-			{
-				WinnerTeam = winnerLogo,
-				LoserTeam = loserLogo,
-				Round = round.Value,
-				Score = ResolveScore(match, winner.Id, loser.Id),
-				IsBestOfThree = match.NumberOfGames == 3
-			});
-		}
-
-		return [.. results.OrderBy(r => r.Round)];
+		return PandaScoreMatchMapper.ToCompletedMatchResults(matches, teams);
 	}
 
 	public async Task<List<SimulatorLiveMatch>> GetLiveMatchesAsync(string eventId, Stages stage)
@@ -81,8 +41,8 @@ public partial class PandaScoreResultsService(IPandaScoreResultsCachingService c
 			if (opponents.Count != 2)
 				continue;
 
-			var teamALogo = ResolveLogoFileName(teams, opponents[0].Name);
-			var teamBLogo = ResolveLogoFileName(teams, opponents[1].Name);
+			var teamALogo = PandaScoreMatchMapper.ResolveLogoFileName(teams, opponents[0].Name);
+			var teamBLogo = PandaScoreMatchMapper.ResolveLogoFileName(teams, opponents[1].Name);
 
 			// Unresolved team name — skip rather than guess, same as the completed-matches path.
 			if (teamALogo is null || teamBLogo is null)
@@ -97,66 +57,4 @@ public partial class PandaScoreResultsService(IPandaScoreResultsCachingService c
 
 		return results;
 	}
-
-	private static string? ResolveLogoFileName(IReadOnlyCollection<Team> teams, string? pandaScoreTeamName)
-	{
-		if (pandaScoreTeamName is null)
-			return null;
-
-		var exactMatches = teams.Where(x => x.Name!.Equals(pandaScoreTeamName, StringComparison.CurrentCultureIgnoreCase)).ToList();
-
-		if (exactMatches.Count == 1)
-			return $"{exactMatches[0].Logo}.png";
-
-		// PandaScore and Steam sometimes use slightly different variants of the same org's name
-		// (eg. "Liquid" vs "Team Liquid", "BetBoom Team" vs "BetBoom") — fall back to a
-		// normalized substring match, but only commit when it resolves to exactly one candidate.
-		string normalizedPandaScoreName = Normalize(pandaScoreTeamName);
-
-		var fuzzyMatches = teams
-			.Where(x =>
-			{
-				string normalizedTeamName = Normalize(x.Name!);
-
-				if (normalizedTeamName == normalizedPandaScoreName
-					|| normalizedTeamName.Contains(normalizedPandaScoreName)
-					|| normalizedPandaScoreName.Contains(normalizedTeamName))
-					return true;
-
-				// Some orgs are commonly referred to by an initialism of their full name
-				// (eg. "NiP" for "Ninjas in Pyjamas") — the initials aren't a contiguous
-				// substring of the space-stripped name, so the checks above miss it.
-				return GetInitials(x.Name!) == normalizedPandaScoreName
-					|| GetInitials(pandaScoreTeamName) == normalizedTeamName;
-			})
-			.ToList();
-
-		return fuzzyMatches.Count == 1 ? $"{fuzzyMatches[0].Logo}.png" : null;
-	}
-
-	private static string? ResolveScore(PandaScoreMatch match, int winnerId, int loserId)
-	{
-		var winnerResult = match.Results.FirstOrDefault(r => r.TeamId == winnerId);
-		var loserResult = match.Results.FirstOrDefault(r => r.TeamId == loserId);
-
-		return winnerResult is not null && loserResult is not null
-			? $"{winnerResult.Score}-{loserResult.Score}"
-			: null;
-	}
-
-	private static string Normalize(string name) =>
-		string.Concat(name.Where(char.IsLetterOrDigit)).ToLowerInvariant();
-
-	private static string GetInitials(string name) =>
-		string.Concat(name.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(word => word[0])).ToLowerInvariant();
-
-	private static int? ParseRound(string matchName)
-	{
-		var match = RoundNumberRegex().Match(matchName);
-
-		return match.Success ? int.Parse(match.Groups[1].Value) : null;
-	}
-
-	[GeneratedRegex(@"^Round (\d+):", RegexOptions.IgnoreCase)]
-	private static partial Regex RoundNumberRegex();
 }

--- a/src/PickemsPlanter/Services/SeedsTableService.cs
+++ b/src/PickemsPlanter/Services/SeedsTableService.cs
@@ -8,6 +8,7 @@ namespace PickemsPlanter.Services;
 public interface ISeedsTableService
 {
 	Task<IReadOnlyCollection<Seed>> GetSeedsInStageAsync(Stages stage, string eventId);
+	Task UpsertSeedsAsync(Stages stage, string eventId, IReadOnlyDictionary<string, int> teamNameToRank);
 }
 
 public class SeedsTableService(TableServiceClient tableServiceClient) : ISeedsTableService
@@ -19,13 +20,29 @@ public class SeedsTableService(TableServiceClient tableServiceClient) : ISeedsTa
 
 		AsyncPageable<Seed> query = client.QueryAsync<Seed>(x => x.PartitionKey == eventId);
 
-		List<Seed> results = []; 
-		
-		await foreach (var item in query) 
-		{ 
-			results.Add(item); 
+		List<Seed> results = [];
+
+		await foreach (var item in query)
+		{
+			results.Add(item);
 		}
 
 		return [.. results.OrderBy(s => s.Rank)];
+	}
+
+	public async Task UpsertSeedsAsync(Stages stage, string eventId, IReadOnlyDictionary<string, int> teamNameToRank)
+	{
+		string tableName = stage.ToString().ToLower();
+		TableClient client = tableServiceClient.GetTableClient(tableName);
+
+		foreach (var (teamName, rank) in teamNameToRank)
+		{
+			TableEntity entity = new(eventId, teamName)
+			{
+				{ nameof(Seed.Rank), rank }
+			};
+
+			await client.UpsertEntityAsync(entity, TableUpdateMode.Merge);
+		}
 	}
 }

--- a/src/PickemsPlanter/Services/SwissStandingsCalculator.cs
+++ b/src/PickemsPlanter/Services/SwissStandingsCalculator.cs
@@ -1,0 +1,100 @@
+using PickemsPlanter.Models.Simulator;
+
+namespace PickemsPlanter.Services;
+
+// One team's final standing in a resolved 16-team Swiss stage. Team is a logo filename
+// (eg. "spirit.png"), matching SimulatorMatchResult's team identifiers.
+public record SwissStanding(string Team, int Wins, int Losses, int Buchholz, int InitialSeed);
+
+public interface ISwissStandingsCalculator
+{
+	bool TryCalculateFinalStandings(
+		IReadOnlyCollection<SimulatorMatchResult> results,
+		IReadOnlyDictionary<string, int> initialSeedByTeam,
+		out IReadOnlyList<SwissStanding> standings);
+}
+
+// Server-side port of the DOM-based Buchholz/standings logic in wwwroot/js/Simulator/simulator.js
+// (calculateNewBuchholzScores/getBracketId/getTeamsPreviousOpponents/orderSwissGroup), operating
+// on a stage's full completed-match list instead of live DOM state.
+//
+// Deliberate deviation from a literal port: the client only ever has a partial, incrementally
+// updated DOM, so it computes each team's Buchholz once per round and freezes it — an opponent
+// locked in earlier (eg. 3-0 after round 2) never has their contribution refreshed with data
+// from rounds that finish later for other teams. Here we always have the complete, final result
+// set up front, so Buchholz is computed once, using every opponent's true final (Wins - Losses)
+// — the standard Buchholz/"difficulty score" definition, and strictly more correct than
+// replaying the client's staleness artifact.
+public class SwissStandingsCalculator : ISwissStandingsCalculator
+{
+	public bool TryCalculateFinalStandings(
+		IReadOnlyCollection<SimulatorMatchResult> results,
+		IReadOnlyDictionary<string, int> initialSeedByTeam,
+		out IReadOnlyList<SwissStanding> standings)
+	{
+		standings = [];
+
+		if (results.Count == 0)
+			return false;
+
+		Dictionary<string, (int Wins, int Losses)> records = [];
+		Dictionary<string, List<string>> opponentsByTeam = [];
+
+		foreach (var result in results)
+		{
+			RecordOpponent(opponentsByTeam, result.WinnerTeam, result.LoserTeam);
+			RecordOpponent(opponentsByTeam, result.LoserTeam, result.WinnerTeam);
+
+			var (winnerWins, winnerLosses) = records.GetValueOrDefault(result.WinnerTeam);
+			records[result.WinnerTeam] = (winnerWins + 1, winnerLosses);
+
+			var (loserWins, loserLosses) = records.GetValueOrDefault(result.LoserTeam);
+			records[result.LoserTeam] = (loserWins, loserLosses + 1);
+		}
+
+		// A resolved 16-team Swiss stage always ends with every team at a terminal 3-x/x-3
+		// record — if that's not the case yet, the stage isn't actually done.
+		if (records.Count != 16 || records.Values.Any(r => r.Wins != 3 && r.Losses != 3))
+			return false;
+
+		List<SwissStanding> calculated = [];
+
+		foreach (var (team, record) in records)
+		{
+			// Can't tiebreak a team we don't have an initial seed for — bail rather than
+			// guess an order (this points at a name-resolution gap between data sources).
+			if (!initialSeedByTeam.TryGetValue(team, out int initialSeed))
+				return false;
+
+			int buchholz = opponentsByTeam[team].Sum(opponent =>
+			{
+				var opponentRecord = records[opponent];
+				return opponentRecord.Wins - opponentRecord.Losses;
+			});
+
+			calculated.Add(new SwissStanding(team, record.Wins, record.Losses, buchholz, initialSeed));
+		}
+
+		// Wins is 3 for every advancing team, so it alone can't separate 3-0 from 3-1 from
+		// 3-2 — fewer losses is a strictly better finish and must outrank Buchholz, which only
+		// tiebreaks within an otherwise-equal record.
+		standings = [.. calculated
+			.OrderByDescending(s => s.Wins)
+			.ThenBy(s => s.Losses)
+			.ThenByDescending(s => s.Buchholz)
+			.ThenBy(s => s.InitialSeed)];
+
+		return true;
+	}
+
+	private static void RecordOpponent(Dictionary<string, List<string>> opponentsByTeam, string team, string opponent)
+	{
+		if (!opponentsByTeam.TryGetValue(team, out var opponents))
+		{
+			opponents = [];
+			opponentsByTeam[team] = opponents;
+		}
+
+		opponents.Add(opponent);
+	}
+}

--- a/tests/PickemsPlanter.Tests/Services/AdvancingSeedAutomationServiceTests.cs
+++ b/tests/PickemsPlanter.Tests/Services/AdvancingSeedAutomationServiceTests.cs
@@ -1,0 +1,223 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using PickemsPlanter.Models.Event;
+using PickemsPlanter.Models.Simulator;
+using PickemsPlanter.Models.Steam;
+using PickemsPlanter.Models.StorageAccount;
+using Xunit;
+
+namespace PickemsPlanter.Services;
+
+public class AdvancingSeedAutomationServiceTests
+{
+	private readonly AdvancingSeedAutomationService _service;
+	private readonly ISeedsTableService _seedsTableService = Substitute.For<ISeedsTableService>();
+	private readonly ITournamentCachingService _tournamentCachingService = Substitute.For<ITournamentCachingService>();
+	private readonly ISwissStandingsCalculator _standingsCalculator = Substitute.For<ISwissStandingsCalculator>();
+	private readonly ILogger<AdvancingSeedAutomationService> _logger = Substitute.For<ILogger<AdvancingSeedAutomationService>>();
+
+	private static readonly string[] Letters = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"];
+
+	public AdvancingSeedAutomationServiceTests()
+	{
+		_service = new(_seedsTableService, _tournamentCachingService, _standingsCalculator, _logger);
+	}
+
+	private static List<Team> AllTeams() =>
+		[.. Letters.Select(l => new Team { Name = $"Team {l.ToUpperInvariant()}", Logo = $"team{l}" })];
+
+	private static List<Seed> AllCurrentSeeds(string eventId) =>
+		[.. Letters.Select((l, i) => new Seed { PartitionKey = eventId, RowKey = $"Team {l.ToUpperInvariant()}", Rank = i + 1 })];
+
+	private static List<SimulatorMatchResult> NonEmptyMatches() => [new() { WinnerTeam = "teama.png", LoserTeam = "teamb.png", Round = 1, IsBestOfThree = false }];
+
+	private void ReturnsStandings(IReadOnlyList<SwissStanding> standings)
+	{
+		_standingsCalculator
+			.TryCalculateFinalStandings(Arg.Any<IReadOnlyCollection<SimulatorMatchResult>>(), Arg.Any<IReadOnlyDictionary<string, int>>(), out Arg.Any<IReadOnlyList<SwissStanding>>())
+			.Returns(x =>
+			{
+				x[2] = standings;
+				return true;
+			});
+	}
+
+	[Theory]
+	[InlineData(Stages.Stage3)]
+	[InlineData(Stages.Playoffs)]
+	public async Task ApplyAdvancingSeedsAsync_DoesNothing_WhenStageHasNoNextStage(Stages stage)
+	{
+		// Act
+		await _service.ApplyAdvancingSeedsAsync("25", stage, NonEmptyMatches());
+
+		// Assert
+		await _seedsTableService.DidNotReceiveWithAnyArgs().GetSeedsInStageAsync(default, default!);
+	}
+
+	[Fact]
+	public async Task ApplyAdvancingSeedsAsync_DoesNothing_WhenNoCompletedMatches()
+	{
+		// Act
+		await _service.ApplyAdvancingSeedsAsync("25", Stages.Stage1, []);
+
+		// Assert
+		await _seedsTableService.DidNotReceiveWithAnyArgs().GetSeedsInStageAsync(default, default!);
+	}
+
+	[Fact]
+	public async Task ApplyAdvancingSeedsAsync_DoesNothing_WhenCurrentStageSeedingIsIncomplete()
+	{
+		// Arrange — only 15 of the 16 seeds entered for the current stage.
+		string eventId = "25";
+		_seedsTableService.GetSeedsInStageAsync(Stages.Stage1, eventId).Returns(AllCurrentSeeds(eventId).Take(15).ToList());
+
+		// Act
+		await _service.ApplyAdvancingSeedsAsync(eventId, Stages.Stage1, NonEmptyMatches());
+
+		// Assert
+		await _tournamentCachingService.DidNotReceive().GetTournamentTeamsAsync(eventId);
+		await _seedsTableService.DidNotReceiveWithAnyArgs().UpsertSeedsAsync(default, default!, default!);
+	}
+
+	[Fact]
+	public async Task ApplyAdvancingSeedsAsync_DoesNothing_WhenASeededTeamNameDoesNotResolveToATeam()
+	{
+		// Arrange — one seed's RowKey doesn't match any tournament team.
+		string eventId = "25";
+		var seeds = AllCurrentSeeds(eventId);
+		seeds[0].RowKey = "Some Unknown Team";
+
+		_seedsTableService.GetSeedsInStageAsync(Stages.Stage1, eventId).Returns(seeds);
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(AllTeams());
+
+		// Act
+		await _service.ApplyAdvancingSeedsAsync(eventId, Stages.Stage1, NonEmptyMatches());
+
+		// Assert
+		_standingsCalculator.DidNotReceiveWithAnyArgs().TryCalculateFinalStandings(default!, default!, out Arg.Any<IReadOnlyList<SwissStanding>>());
+		await _seedsTableService.DidNotReceiveWithAnyArgs().UpsertSeedsAsync(default, default!, default!);
+	}
+
+	[Fact]
+	public async Task ApplyAdvancingSeedsAsync_DoesNothing_WhenStandingsCalculatorFails()
+	{
+		// Arrange
+		string eventId = "25";
+		_seedsTableService.GetSeedsInStageAsync(Stages.Stage1, eventId).Returns(AllCurrentSeeds(eventId));
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(AllTeams());
+
+		_standingsCalculator
+			.TryCalculateFinalStandings(Arg.Any<IReadOnlyCollection<SimulatorMatchResult>>(), Arg.Any<IReadOnlyDictionary<string, int>>(), out Arg.Any<IReadOnlyList<SwissStanding>>())
+			.Returns(false);
+
+		// Act
+		await _service.ApplyAdvancingSeedsAsync(eventId, Stages.Stage1, NonEmptyMatches());
+
+		// Assert
+		await _seedsTableService.DidNotReceiveWithAnyArgs().UpsertSeedsAsync(default, default!, default!);
+	}
+
+	[Fact]
+	public async Task ApplyAdvancingSeedsAsync_DoesNothing_WhenStandingsDoNotHaveExactlyEightAdvancingTeams()
+	{
+		// Arrange — only 7 teams reached 3 wins; the underlying data can't be trusted to
+		// derive a clean 9-16 split, so this should refuse rather than guess.
+		string eventId = "25";
+		_seedsTableService.GetSeedsInStageAsync(Stages.Stage1, eventId).Returns(AllCurrentSeeds(eventId));
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(AllTeams());
+
+		List<SwissStanding> standings =
+		[
+			new("teama.png", 3, 0, 0, 1), new("teamb.png", 3, 0, 0, 2), new("teamc.png", 3, 1, 0, 3),
+			new("teamd.png", 3, 1, 0, 4), new("teame.png", 3, 2, 0, 5), new("teamf.png", 3, 2, 0, 6),
+			new("teamg.png", 3, 2, 0, 7), new("teamh.png", 2, 3, 0, 8), new("teami.png", 2, 3, 0, 9),
+			new("teamj.png", 1, 3, 0, 10), new("teamk.png", 1, 3, 0, 11), new("teaml.png", 0, 3, 0, 12),
+			new("teamm.png", 0, 3, 0, 13), new("teamn.png", 0, 3, 0, 14), new("teamo.png", 0, 3, 0, 15),
+			new("teamp.png", 0, 3, 0, 16)
+		];
+		ReturnsStandings(standings);
+
+		// Act
+		await _service.ApplyAdvancingSeedsAsync(eventId, Stages.Stage1, NonEmptyMatches());
+
+		// Assert
+		await _seedsTableService.DidNotReceiveWithAnyArgs().UpsertSeedsAsync(default, default!, default!);
+	}
+
+	[Fact]
+	public async Task ApplyAdvancingSeedsAsync_UpsertsSeeds9Through16_InStandingsOrder_IntoTheNextStage()
+	{
+		// Arrange
+		string eventId = "25";
+		_seedsTableService.GetSeedsInStageAsync(Stages.Stage1, eventId).Returns(AllCurrentSeeds(eventId));
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(AllTeams());
+
+		List<SwissStanding> standings =
+		[
+			new("teama.png", 3, 0, 10, 1),
+			new("teamb.png", 3, 0, 5, 2),
+			new("teamc.png", 0, 3, -5, 9),
+			new("teamd.png", 3, 1, 3, 3),
+			new("teame.png", 3, 1, 2, 4),
+			new("teamf.png", 1, 3, -2, 10),
+			new("teamg.png", 3, 2, 1, 5),
+			new("teamh.png", 3, 2, 0, 6),
+			new("teami.png", 3, 2, -1, 7),
+			new("teamj.png", 2, 3, -3, 11),
+			new("teamk.png", 2, 3, -4, 12),
+			new("teaml.png", 0, 3, -6, 13),
+			new("teamm.png", 1, 3, -7, 14),
+			new("teamn.png", 0, 3, -8, 15),
+			new("teamo.png", 0, 3, -9, 16),
+			new("teamp.png", 3, 2, -10, 8)
+		];
+		ReturnsStandings(standings);
+
+		// Act
+		await _service.ApplyAdvancingSeedsAsync(eventId, Stages.Stage1, NonEmptyMatches());
+
+		// Assert
+		Dictionary<string, int> expected = new()
+		{
+			["Team A"] = 9,
+			["Team B"] = 10,
+			["Team D"] = 11,
+			["Team E"] = 12,
+			["Team G"] = 13,
+			["Team H"] = 14,
+			["Team I"] = 15,
+			["Team P"] = 16
+		};
+
+		await _seedsTableService.Received(1).UpsertSeedsAsync(
+			Stages.Stage2,
+			eventId,
+			Arg.Is<IReadOnlyDictionary<string, int>>(d => d.Count == expected.Count && expected.All(kv => d.ContainsKey(kv.Key) && d[kv.Key] == kv.Value)));
+	}
+
+	[Fact]
+	public async Task ApplyAdvancingSeedsAsync_WritesIntoStage3_WhenGivenStage2()
+	{
+		// Arrange
+		string eventId = "25";
+		_seedsTableService.GetSeedsInStageAsync(Stages.Stage2, eventId).Returns(AllCurrentSeeds(eventId));
+		_tournamentCachingService.GetTournamentTeamsAsync(eventId).Returns(AllTeams());
+
+		List<SwissStanding> standings =
+		[
+			new("teama.png", 3, 0, 0, 1), new("teamb.png", 3, 0, 0, 2), new("teamc.png", 3, 1, 0, 3),
+			new("teamd.png", 3, 1, 0, 4), new("teame.png", 3, 2, 0, 5), new("teamf.png", 3, 2, 0, 6),
+			new("teamg.png", 3, 2, 0, 7), new("teamh.png", 3, 2, 0, 8), new("teami.png", 2, 3, 0, 9),
+			new("teamj.png", 1, 3, 0, 10), new("teamk.png", 1, 3, 0, 11), new("teaml.png", 0, 3, 0, 12),
+			new("teamm.png", 0, 3, 0, 13), new("teamn.png", 0, 3, 0, 14), new("teamo.png", 0, 3, 0, 15),
+			new("teamp.png", 0, 3, 0, 16)
+		];
+		ReturnsStandings(standings);
+
+		// Act
+		await _service.ApplyAdvancingSeedsAsync(eventId, Stages.Stage2, NonEmptyMatches());
+
+		// Assert
+		await _seedsTableService.Received(1).UpsertSeedsAsync(Stages.Stage3, eventId, Arg.Any<IReadOnlyDictionary<string, int>>());
+	}
+}

--- a/tests/PickemsPlanter.Tests/Services/PandaScoreResultsCachingServiceTests.cs
+++ b/tests/PickemsPlanter.Tests/Services/PandaScoreResultsCachingServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using PickemsPlanter.APIs;
@@ -14,14 +15,18 @@ public class PandaScoreResultsCachingServiceTests
 	private readonly PandaScoreResultsCachingService _service;
 	private readonly IPandaScoreApi _pandaScoreApi = Substitute.For<IPandaScoreApi>();
 	private readonly IEventTableService _eventTableService = Substitute.For<IEventTableService>();
+	private readonly ITournamentCachingService _tournamentCachingService = Substitute.For<ITournamentCachingService>();
+	private readonly IAdvancingSeedAutomationService _advancingSeedAutomationService = Substitute.For<IAdvancingSeedAutomationService>();
 	private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
 	private readonly IOptionsMonitor<PandaScoreConfig> _config = Substitute.For<IOptionsMonitor<PandaScoreConfig>>();
+	private readonly ILogger<PandaScoreResultsCachingService> _logger = Substitute.For<ILogger<PandaScoreResultsCachingService>>();
 
 	public PandaScoreResultsCachingServiceTests()
 	{
 		_config.CurrentValue.Returns(new PandaScoreConfig { ApiToken = "token", Enabled = true, PollingIntervalMinutes = 10 });
+		_tournamentCachingService.GetTournamentTeamsAsync(Arg.Any<string>()).Returns([]);
 
-		_service = new(_pandaScoreApi, _eventTableService, _cache, _config);
+		_service = new(_pandaScoreApi, _eventTableService, _tournamentCachingService, _advancingSeedAutomationService, _cache, _config, _logger);
 	}
 
 	private static PandaScoreMatch FinishedMatch(int id, int winnerId) => new()

--- a/tests/PickemsPlanter.Tests/Services/SwissStandingsCalculatorTests.cs
+++ b/tests/PickemsPlanter.Tests/Services/SwissStandingsCalculatorTests.cs
@@ -1,0 +1,123 @@
+using PickemsPlanter.Models.Simulator;
+using Xunit;
+
+namespace PickemsPlanter.Services;
+
+public class SwissStandingsCalculatorTests
+{
+	private readonly SwissStandingsCalculator _calculator = new();
+
+	// A fully resolved, hand-verified 16-team Swiss stage. T1-T8 finish 3-x (advancing),
+	// T9-T16 finish x-3 (eliminated). Buchholz for each advancing team is each opponent's
+	// final (Wins - Losses) summed, matching the standard Buchholz/"difficulty score"
+	// definition simulator.js approximates client-side (see SwissStandingsCalculator's
+	// class comment for why this port uses true-final rather than round-frozen values).
+	private static List<SimulatorMatchResult> FullyResolvedStage() =>
+	[
+		Match("t1.png", "t9.png"), Match("t1.png", "t10.png"), Match("t1.png", "t11.png"),
+		Match("t2.png", "t12.png"), Match("t2.png", "t13.png"), Match("t2.png", "t14.png"),
+		Match("t3.png", "t15.png"), Match("t3.png", "t16.png"), Match("t3.png", "t9.png"),
+		Match("t4.png", "t10.png"), Match("t4.png", "t11.png"), Match("t4.png", "t12.png"),
+		Match("t5.png", "t13.png"), Match("t5.png", "t14.png"), Match("t5.png", "t15.png"),
+		Match("t6.png", "t16.png"), Match("t6.png", "t9.png"), Match("t6.png", "t10.png"),
+		Match("t7.png", "t11.png"), Match("t7.png", "t12.png"), Match("t7.png", "t13.png"),
+		Match("t8.png", "t14.png"), Match("t8.png", "t15.png"), Match("t8.png", "t16.png"),
+
+		// Upsets: each of these gives an eliminated team one of its (0-2) wins, and gives
+		// the advancing team one of its (0-2) losses.
+		Match("t9.png", "t5.png"), Match("t9.png", "t6.png"),
+		Match("t10.png", "t5.png"), Match("t10.png", "t7.png"),
+		Match("t11.png", "t6.png"), Match("t11.png", "t7.png"),
+		Match("t12.png", "t3.png"),
+		Match("t13.png", "t4.png"),
+		Match("t14.png", "t8.png")
+	];
+
+	private static Dictionary<string, int> SeedsByTeam() =>
+		Enumerable.Range(1, 16).ToDictionary(n => $"t{n}.png", n => n);
+
+	private static SimulatorMatchResult Match(string winner, string loser) => new()
+	{
+		WinnerTeam = winner,
+		LoserTeam = loser,
+		Round = 1,
+		IsBestOfThree = false
+	};
+
+	[Fact]
+	public void TryCalculateFinalStandings_ReturnsFalse_WhenNoResults()
+	{
+		// Act
+		bool success = _calculator.TryCalculateFinalStandings([], SeedsByTeam(), out var standings);
+
+		// Assert
+		Assert.False(success);
+		Assert.Empty(standings);
+	}
+
+	[Fact]
+	public void TryCalculateFinalStandings_ReturnsFalse_WhenFewerThan16TeamsAppear()
+	{
+		// Arrange — only a handful of the 16 teams have played any match.
+		List<SimulatorMatchResult> results = [Match("t1.png", "t9.png"), Match("t1.png", "t10.png")];
+
+		// Act
+		bool success = _calculator.TryCalculateFinalStandings(results, SeedsByTeam(), out var standings);
+
+		// Assert
+		Assert.False(success);
+	}
+
+	[Fact]
+	public void TryCalculateFinalStandings_ReturnsFalse_WhenATeamHasNotReachedATerminalRecord()
+	{
+		// Arrange — same as the fully resolved stage, but t8 is missing one of its wins
+		// (t14 beating t8 is still present), leaving t8 at 2-1 instead of a terminal 3-x/x-3.
+		var results = FullyResolvedStage();
+		results.RemoveAll(r => r.WinnerTeam == "t8.png" && r.LoserTeam == "t14.png");
+
+		// Act
+		bool success = _calculator.TryCalculateFinalStandings(results, SeedsByTeam(), out var standings);
+
+		// Assert
+		Assert.False(success);
+	}
+
+	[Fact]
+	public void TryCalculateFinalStandings_ReturnsFalse_WhenATeamHasNoInitialSeed()
+	{
+		// Arrange
+		var seeds = SeedsByTeam();
+		seeds.Remove("t1.png");
+
+		// Act
+		bool success = _calculator.TryCalculateFinalStandings(FullyResolvedStage(), seeds, out var standings);
+
+		// Assert
+		Assert.False(success);
+	}
+
+	[Fact]
+	public void TryCalculateFinalStandings_OrdersAdvancingTeams_ByRecordThenBuchholzThenSeed()
+	{
+		// Act
+		bool success = _calculator.TryCalculateFinalStandings(FullyResolvedStage(), SeedsByTeam(), out var standings);
+
+		// Assert
+		Assert.True(success);
+		Assert.Equal(16, standings.Count);
+
+		var advancing = standings.Where(s => s.Wins == 3).ToList();
+		Assert.Equal(8, advancing.Count);
+
+		// t1,t2: 3-0, Buchholz -3 and -6 respectively — record ties, Buchholz decides.
+		// t4,t3,t8: 3-1, Buchholz -6/-9/-10 — Buchholz outranks seed (t4 has the worse seed
+		// of the three but the best Buchholz among them).
+		// t6,t7,t5: 3-2, Buchholz -7/-7/-9 — t6/t7 tie on Buchholz, seed (6 < 7) breaks the tie.
+		string[] expectedOrder = ["t1.png", "t2.png", "t4.png", "t3.png", "t8.png", "t6.png", "t7.png", "t5.png"];
+		Assert.Equal(expectedOrder, advancing.Select(s => s.Team));
+
+		var eliminated = standings.Where(s => s.Wins < 3).Select(s => s.Team).ToHashSet();
+		Assert.Equal(Enumerable.Range(9, 8).Select(n => $"t{n}.png").ToHashSet(), eliminated);
+	}
+}


### PR DESCRIPTION
## Summary
Closes #138. Per Valve's Major Supplemental Rulebook, a Stage 2/3 bracket's seeds 9-16 are always the previous stage's advancing teams, ordered by that stage's own record/Buchholz/seed tiebreak. This automates that half of seeding:

- `SwissStandingsCalculator` — server-side port of the Buchholz/standings logic in `wwwroot/js/Simulator/simulator.js`, operating on a stage's complete match history instead of live DOM state.
- `PandaScoreMatchMapper` — match-mapping and fuzzy team-name matching extracted out of `PandaScoreResultsService` so it can be reused without creating a DI cycle back through `IPandaScoreResultsCachingService`.
- `AdvancingSeedAutomationService` — detects a fully-resolved Swiss stage, computes final standings, and auto-writes seeds 9-16 into the next stage's table. Auto-applies with no confirmation step (decided scope for #138).
- `SeedsTableService.UpsertSeedsAsync` — new merge-upsert write path.
- Hooked into `PandaScoreResultsCachingService.RefreshStageAsync`, wrapped so a failure there can never break match caching or the poll loop.

Seeds 1-8 (pre-qualified invites) remain manual until the HLTV importer (issue #147) ships.

## Test plan
- [x] `dotnet build src/PickemsPlanter.sln`
- [x] `dotnet test src/PickemsPlanter.sln` — 96 passed, 0 failed (14 new tests covering the calculator and automation service)
- [x] Verified locally against a real event's Stage 1 → Stage 2 seed derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)