### PR TITLE
Fix IDOR: derive SteamId from auth claim, not the query string

### DIFF
--- a/src/PickemsPlanter/Pages/PickEms/Playoffs.cshtml.cs
+++ b/src/PickemsPlanter/Pages/PickEms/Playoffs.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using PickemsPlanter.Services;
+using System.Security.Claims;
 
 namespace PickemsPlanter.Pages.PickEms;
 
@@ -13,8 +14,10 @@ public class PlayoffsModel(IPickemsService pickemsService, IHttpContextAccessor 
 	[BindProperty(SupportsGet = true)]
 	public required string EventName { get; init; }
 
-	[BindProperty(SupportsGet = true)]
-	public required string SteamId { get; init; }
+	// Always the authenticated user's own Steam ID, never a client-supplied value —
+	// binding this from the query string let anyone view/overwrite another user's
+	// picks by editing the URL (see #151).
+	public required string SteamId = httpContextAccessor?.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
 
 	[BindProperty(SupportsGet = true)]
 	public string? SelectedEvent { get; init; }
@@ -60,8 +63,7 @@ public class PlayoffsModel(IPickemsService pickemsService, IHttpContextAccessor 
 		return RedirectToPage("/PickEms/Playoffs", new
 		{
 			EventId,
-			EventName,
-			SteamId
+			EventName
 		});
 	}
 }

--- a/src/PickemsPlanter/Pages/PickEms/Stage.cshtml.cs
+++ b/src/PickemsPlanter/Pages/PickEms/Stage.cshtml.cs
@@ -2,6 +2,7 @@ using PickemsPlanter.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using PickemsPlanter.Models.Event;
+using System.Security.Claims;
 
 namespace PickemsPlanter.Pages.PickEms;
 
@@ -13,8 +14,10 @@ public class StageModel(IPickemsService pickemsService, IHttpContextAccessor htt
 	[BindProperty(SupportsGet = true)]
 	public required string EventName { get; init; }
 
-	[BindProperty(SupportsGet = true)]
-	public required string SteamId { get; init; }
+	// Always the authenticated user's own Steam ID, never a client-supplied value —
+	// binding this from the query string let anyone view/overwrite another user's
+	// picks by editing the URL (see #151).
+	public required string SteamId = httpContextAccessor?.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
 
     [BindProperty(SupportsGet = true)]
     public required Stages Stage { get; init; }
@@ -65,7 +68,6 @@ public class StageModel(IPickemsService pickemsService, IHttpContextAccessor htt
 		{
 			EventId,
 			EventName,
-			SteamId,
 			stage = Stage
 		});
 	}


### PR DESCRIPTION
## Summary
- `Stage.cshtml.cs` and `Playoffs.cshtml.cs` bound `SteamId` from the query string/form instead of the authenticated cookie principal, so any logged-in user could view or overwrite another user's picks by editing `steamId` in the URL.
- Both now derive `SteamId` from `ClaimTypes.NameIdentifier`, matching the pattern `Overview.cshtml.cs` already uses for every redirect into these pages.

Fixes #151

## Test plan
- [x] `dotnet build src/PickemsPlanter.sln` — succeeds, 0 warnings/errors
- [x] `dotnet test src/PickemsPlanter.sln` — 141/141 passing
- [ ] Manual: log in as two different Steam accounts, confirm neither can view/edit the other's picks by editing `steamId` in the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)