### PR TITLE
Add rate limiting to Steam-backed login and PickEms endpoints

### DIFF
--- a/src/PickemsPlanter/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PickemsPlanter/Extensions/ServiceCollectionExtensions.cs
@@ -1,11 +1,13 @@
 ﻿using Azure.Data.Tables;
 using Azure.Identity;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
 using PickemsPlanter.APIs;
 using PickemsPlanter.Models.Configurations;
 using PickemsPlanter.Services;
 using System.Security.Claims;
 using System.Text.Json;
+using System.Threading.RateLimiting;
 
 namespace PickemsPlanter.Extensions;
 
@@ -20,6 +22,7 @@ public static class ServiceCollectionExtensions
 			services.AddJsonSerialization();
 			services.AddHttpClients(config);
 			services.AddTableStorage(config);
+			services.AddRateLimiting();
 
 			services.AddRazorPages();
 			services.AddSingleton<IPickemsService, PickemsService>();
@@ -87,6 +90,37 @@ public static class ServiceCollectionExtensions
 			string? pandaScoreAPIURL = config["PandaScore:ApiUrl"];
 
 			services.AddHttpClient<IPandaScoreApi, PandaScoreAPI>(opt => opt.BaseAddress = new Uri(pandaScoreAPIURL!));
+		}
+
+		// Bounds how hard a traffic spike can hammer the Steam Web API key, which is
+		// shared across every user — a burned/rate-limited key breaks the app for
+		// everyone, not just the caller responsible. "SteamApi" covers the PickEms
+		// read/write handlers; "Auth" is tighter since the OpenID callback is
+		// unauthenticated and only needs to fire once per real login.
+		public void AddRateLimiting()
+		{
+			services.AddRateLimiter(options =>
+			{
+				options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+				options.AddPolicy("SteamApi", httpContext => RateLimitPartition.GetFixedWindowLimiter(
+					partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+					factory: _ => new FixedWindowRateLimiterOptions
+					{
+						PermitLimit = 60,
+						Window = TimeSpan.FromMinutes(1),
+						QueueLimit = 0
+					}));
+
+				options.AddPolicy("Auth", httpContext => RateLimitPartition.GetFixedWindowLimiter(
+					partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+					factory: _ => new FixedWindowRateLimiterOptions
+					{
+						PermitLimit = 10,
+						Window = TimeSpan.FromMinutes(1),
+						QueueLimit = 0
+					}));
+			});
 		}
 
 		public void AddTableStorage(IConfiguration config)

--- a/src/PickemsPlanter/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PickemsPlanter/Extensions/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class ServiceCollectionExtensions
 			services.AddJsonSerialization();
 			services.AddHttpClients(config);
 			services.AddTableStorage(config);
-			services.AddRateLimiting();
+			services.AddRateLimiting(config);
 
 			services.AddRazorPages();
 			services.AddSingleton<IPickemsService, PickemsService>();
@@ -97,8 +97,12 @@ public static class ServiceCollectionExtensions
 		// everyone, not just the caller responsible. "SteamApi" covers the PickEms
 		// read/write handlers; "Auth" is tighter since the OpenID callback is
 		// unauthenticated and only needs to fire once per real login.
-		public void AddRateLimiting()
+		public void AddRateLimiting(IConfiguration config)
 		{
+			services.AddOptions<RateLimitingConfig>().Bind(config.GetSection(nameof(RateLimitingConfig)));
+
+			RateLimitingConfig rateLimiting = config.GetSection(nameof(RateLimitingConfig)).Get<RateLimitingConfig>() ?? new();
+
 			services.AddRateLimiter(options =>
 			{
 				options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -107,8 +111,8 @@ public static class ServiceCollectionExtensions
 					partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
 					factory: _ => new FixedWindowRateLimiterOptions
 					{
-						PermitLimit = 60,
-						Window = TimeSpan.FromMinutes(1),
+						PermitLimit = rateLimiting.SteamApiPermitLimit,
+						Window = TimeSpan.FromMinutes(rateLimiting.SteamApiWindowMinutes),
 						QueueLimit = 0
 					}));
 
@@ -116,8 +120,8 @@ public static class ServiceCollectionExtensions
 					partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
 					factory: _ => new FixedWindowRateLimiterOptions
 					{
-						PermitLimit = 10,
-						Window = TimeSpan.FromMinutes(1),
+						PermitLimit = rateLimiting.AuthPermitLimit,
+						Window = TimeSpan.FromMinutes(rateLimiting.AuthWindowMinutes),
 						QueueLimit = 0
 					}));
 			});

--- a/src/PickemsPlanter/Models/Configurations/RateLimitingConfig.cs
+++ b/src/PickemsPlanter/Models/Configurations/RateLimitingConfig.cs
@@ -1,0 +1,12 @@
+namespace PickemsPlanter.Models.Configurations;
+
+public class RateLimitingConfig
+{
+	public int SteamApiPermitLimit { get; init; } = 60;
+
+	public int SteamApiWindowMinutes { get; init; } = 1;
+
+	public int AuthPermitLimit { get; init; } = 10;
+
+	public int AuthWindowMinutes { get; init; } = 1;
+}

--- a/src/PickemsPlanter/Pages/PickEms/Playoffs.cshtml.cs
+++ b/src/PickemsPlanter/Pages/PickEms/Playoffs.cshtml.cs
@@ -1,11 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
 using PickemsPlanter.Services;
 using System.Security.Claims;
 
 namespace PickemsPlanter.Pages.PickEms;
 
-
+[EnableRateLimiting("SteamApi")]
 public class PlayoffsModel(IPickemsService pickemsService, IHttpContextAccessor httpContextAccessor, IUserPredictionsCachingService cachingService) : PageModel
 {
 	[BindProperty(SupportsGet = true)]

--- a/src/PickemsPlanter/Pages/PickEms/Stage.cshtml.cs
+++ b/src/PickemsPlanter/Pages/PickEms/Stage.cshtml.cs
@@ -1,11 +1,13 @@
 using PickemsPlanter.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
 using PickemsPlanter.Models.Event;
 using System.Security.Claims;
 
 namespace PickemsPlanter.Pages.PickEms;
 
+[EnableRateLimiting("SteamApi")]
 public class StageModel(IPickemsService pickemsService, IHttpContextAccessor httpContextAccessor, IUserPredictionsCachingService cachingService) : PageModel
 {
 	[BindProperty(SupportsGet = true)]

--- a/src/PickemsPlanter/Pages/Profile/Login.cshtml.cs
+++ b/src/PickemsPlanter/Pages/Profile/Login.cshtml.cs
@@ -2,9 +2,11 @@ using PickemsPlanter.APIs;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace PickemsPlanter.Pages;
 
+[EnableRateLimiting("Auth")]
 public class LoginModel(ILoginAPI loginAPI) : PageModel
 {
         private readonly ILoginAPI _loginAPI = loginAPI;

--- a/src/PickemsPlanter/Pages/Profile/SteamCallback.cshtml.cs
+++ b/src/PickemsPlanter/Pages/Profile/SteamCallback.cshtml.cs
@@ -3,11 +3,13 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
 
 namespace PickemsPlanter.Pages;
 
+[EnableRateLimiting("Auth")]
 public class SteamCallbackModel(ILoginAPI loginAPI, ISteamAPI steamAPI) : PageModel
 {
 	private readonly ILoginAPI _loginAPI = loginAPI;

--- a/src/PickemsPlanter/Program.cs
+++ b/src/PickemsPlanter/Program.cs
@@ -25,6 +25,8 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseRateLimiter();
+
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/src/PickemsPlanter/appsettings.json
+++ b/src/PickemsPlanter/appsettings.json
@@ -28,6 +28,13 @@
     "LookaheadCount": 5
   },
 
+  "RateLimitingConfig": {
+    "SteamApiPermitLimit": 60,
+    "SteamApiWindowMinutes": 1,
+    "AuthPermitLimit": 10,
+    "AuthWindowMinutes": 1
+  },
+
   "KeyVault": {
     "URL": "https://kvcs2.vault.azure.net/"
   },


### PR DESCRIPTION
## Summary
- Adds ASP.NET Core's built-in rate limiter (`services.AddRateLimiter` in `ServiceCollectionExtensions.AddRateLimiting`, `app.UseRateLimiter()` in `Program.cs`).
- Two per-IP, fixed-window policies:
  - `SteamApi` (60 req/min) on `Pages/PickEms/Stage.cshtml.cs` and `Playoffs.cshtml.cs` — covers picks read/write handlers.
  - `Auth` (10 req/min) on `Pages/Profile/Login.cshtml.cs` and `SteamCallback.cshtml.cs` — tighter, since the OpenID callback is unauthenticated and should only fire once per real login.
- Over the limit, requests get a 429 instead of reaching Steam.

Fixes #152

## Test plan
- [x] `dotnet build src/PickemsPlanter.sln` — succeeds, 0 warnings/errors
- [x] `dotnet test src/PickemsPlanter.sln` — 141/141 passing
- [ ] Manual: script >60 requests/min against a Stage page handler and confirm 429s kick in; confirm normal page usage (loading a stage, switching stages, saving picks) stays well under the limit
- Local end-to-end run wasn't possible in this environment (app requires Azure Key Vault credentials at startup to resolve config — pre-existing, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)