### PR TITLE
Add test coverage for PickEms page handlers and Steam/Login API wrappers

### DIFF
--- a/src/PickemsPlanter/Pages/PickEms/Playoffs.cshtml.cs
+++ b/src/PickemsPlanter/Pages/PickEms/Playoffs.cshtml.cs
@@ -18,16 +18,16 @@ public class PlayoffsModel(IPickemsService pickemsService, IHttpContextAccessor 
 	// Always the authenticated user's own Steam ID, never a client-supplied value —
 	// binding this from the query string let anyone view/overwrite another user's
 	// picks by editing the URL (see #151).
-	public required string SteamId = httpContextAccessor?.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
+	public string SteamId = httpContextAccessor?.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
 
 	[BindProperty(SupportsGet = true)]
 	public string? SelectedEvent { get; init; }
 
 	public IReadOnlyCollection<string>? Picks { get; set; }
 
-	public required string? PersonaName = httpContextAccessor?.HttpContext?.User.FindFirst("PersonaName")?.Value;
+	public string? PersonaName = httpContextAccessor?.HttpContext?.User.FindFirst("PersonaName")?.Value;
 
-	public required string? Avatar = httpContextAccessor?.HttpContext?.User.FindFirst("Avatar")?.Value;
+	public string? Avatar = httpContextAccessor?.HttpContext?.User.FindFirst("Avatar")?.Value;
 
 	public async Task<JsonResult> OnGetPicksAllowed()
 	{

--- a/src/PickemsPlanter/Pages/PickEms/Stage.cshtml.cs
+++ b/src/PickemsPlanter/Pages/PickEms/Stage.cshtml.cs
@@ -19,7 +19,7 @@ public class StageModel(IPickemsService pickemsService, IHttpContextAccessor htt
 	// Always the authenticated user's own Steam ID, never a client-supplied value —
 	// binding this from the query string let anyone view/overwrite another user's
 	// picks by editing the URL (see #151).
-	public required string SteamId = httpContextAccessor?.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
+	public string SteamId = httpContextAccessor?.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
 
     [BindProperty(SupportsGet = true)]
     public required Stages Stage { get; init; }
@@ -29,9 +29,9 @@ public class StageModel(IPickemsService pickemsService, IHttpContextAccessor htt
 
 	public IReadOnlyCollection<string>? Picks { get; set; }
 
-    public required string? PersonaName = httpContextAccessor?.HttpContext?.User.FindFirst("PersonaName")?.Value;
+    public string? PersonaName = httpContextAccessor?.HttpContext?.User.FindFirst("PersonaName")?.Value;
 
-    public required string? Avatar = httpContextAccessor?.HttpContext?.User.FindFirst("Avatar")?.Value;
+    public string? Avatar = httpContextAccessor?.HttpContext?.User.FindFirst("Avatar")?.Value;
 
 	public async Task<JsonResult> OnGetPicksAllowed()
 	{

--- a/tests/PickemsPlanter.Tests/APIs/FakeHttpMessageHandler.cs
+++ b/tests/PickemsPlanter.Tests/APIs/FakeHttpMessageHandler.cs
@@ -1,0 +1,15 @@
+namespace PickemsPlanter.APIs;
+
+internal sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+{
+	public HttpRequestMessage? LastRequest { get; private set; }
+	public string? LastRequestBody { get; private set; }
+
+	protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		LastRequest = request;
+		LastRequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+
+		return respond(request);
+	}
+}

--- a/tests/PickemsPlanter.Tests/APIs/LoginAPITests.cs
+++ b/tests/PickemsPlanter.Tests/APIs/LoginAPITests.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using System.Net;
+using System.Web;
+using Xunit;
+
+namespace PickemsPlanter.APIs;
+
+public class LoginAPITests
+{
+	private static (LoginAPI api, FakeHttpMessageHandler handler) MakeApi(Func<HttpRequestMessage, HttpResponseMessage> respond)
+	{
+		var handler = new FakeHttpMessageHandler(respond);
+		var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://steamcommunity.com") };
+
+		return (new LoginAPI(httpClient), handler);
+	}
+
+	[Fact]
+	public void Login_BuildsAnOpenIdCheckidSetupUrl_CarryingTheReturnUrlAndRealm()
+	{
+		var (api, _) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+		string url = api.Login(returnUrl: "https://pickemsplanter.example/Profile/SteamCallback", realm: "https://pickemsplanter.example");
+
+		// HttpClient.BaseAddress.ToString() normalizes to a trailing slash, so this string-concats
+		// to a double slash before "openid" — harmless (Steam's endpoint tolerates it) but real,
+		// pre-existing behavior, not a typo in this assertion.
+		Assert.StartsWith("https://steamcommunity.com//openid/login?", url);
+		Assert.Contains("openid.mode=checkid_setup", url);
+		Assert.Contains($"openid.return_to={HttpUtility.UrlEncode("https://pickemsplanter.example/Profile/SteamCallback")}", url);
+		Assert.Contains($"openid.realm={HttpUtility.UrlEncode("https://pickemsplanter.example")}", url);
+	}
+
+	[Fact]
+	public async Task ValidateLoginAsync_OverridesTheModeToCheckAuthentication_AndForwardsEveryOtherParam()
+	{
+		var (api, handler) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("is_valid:true") });
+
+		var query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["openid.mode"] = "id_res",
+			["openid.claimed_id"] = "https://steamcommunity.com/openid/id/76500000000000001",
+			["openid.sig"] = "some-signature"
+		});
+
+		await api.ValidateLoginAsync(query);
+
+		var form = HttpUtility.ParseQueryString(handler.LastRequestBody!);
+		Assert.Equal("check_authentication", form["openid.mode"]);
+		Assert.Equal("https://steamcommunity.com/openid/id/76500000000000001", form["openid.claimed_id"]);
+		Assert.Equal("some-signature", form["openid.sig"]);
+		Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+	}
+
+	[Fact]
+	public async Task ValidateLoginAsync_ReturnsTheRawResponseBody()
+	{
+		var (api, _) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ns:http://specs.openid.net/auth/2.0\nis_valid:true") });
+
+		string result = await api.ValidateLoginAsync(new QueryCollection());
+
+		Assert.Equal("ns:http://specs.openid.net/auth/2.0\nis_valid:true", result);
+	}
+}

--- a/tests/PickemsPlanter.Tests/APIs/SteamAPITests.cs
+++ b/tests/PickemsPlanter.Tests/APIs/SteamAPITests.cs
@@ -1,0 +1,172 @@
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using PickemsPlanter.Models.Configurations;
+using PickemsPlanter.Models.Steam;
+using System.Net;
+using System.Text.Json;
+using System.Web;
+using Xunit;
+
+namespace PickemsPlanter.APIs;
+
+public class SteamAPITests
+{
+	private static readonly JsonSerializerOptions SerializerOptions = new() { PropertyNameCaseInsensitive = true };
+
+	private static (SteamAPI api, FakeHttpMessageHandler handler) MakeApi(Func<HttpRequestMessage, HttpResponseMessage> respond)
+	{
+		var handler = new FakeHttpMessageHandler(respond);
+		var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.steampowered.com") };
+
+		var config = Substitute.For<IOptionsMonitor<SteamConfig>>();
+		config.CurrentValue.Returns(new SteamConfig { WebApiKey = "test-web-api-key" });
+
+		return (new SteamAPI(httpClient, SerializerOptions, config), handler);
+	}
+
+	private static HttpResponseMessage JsonResponse(string json) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(json) };
+
+	[Fact]
+	public async Task GetPlayerSummeries_SendsTheApiKeyAndSteamId_AndDeserializesTheResponse()
+	{
+		string json = """{"response":{"players":[{"steamId":"76500000000000001","communityVisibilityState":3,"profileState":1,"personaName":"Jake","profileUrl":"url","avatar":"a","avatarMedium":"am","avatarFull":"af","avatarHash":"hash","lastLogOff":0,"personaState":1,"primaryClanId":"0","timeCreated":0,"personaStatFlags":0}]}}""";
+		var (api, handler) = MakeApi(_ => JsonResponse(json));
+
+		var result = await api.GetPlayerSummeries("76500000000000001");
+
+		Assert.Contains("key=test-web-api-key", handler.LastRequest!.RequestUri!.Query);
+		Assert.Contains("steamids=76500000000000001", handler.LastRequest.RequestUri.Query);
+		Assert.Equal("Jake", result.Response.Players.Single().PersonaName);
+	}
+
+	[Fact]
+	public async Task GetTournamentItemsAsync_SendsEventSteamIdAndAuthCode()
+	{
+		string json = """{"result":{"items":[]}}""";
+		var (api, handler) = MakeApi(_ => JsonResponse(json));
+
+		await api.GetTournamentItemsAsync("76500000000000001", "25", "auth-code-abc");
+
+		string query = handler.LastRequest!.RequestUri!.Query;
+		Assert.Contains("event=25", query);
+		Assert.Contains("steamid=76500000000000001", query);
+		Assert.Contains("steamidkey=auth-code-abc", query);
+	}
+
+	[Fact]
+	public async Task GetTournamentLayoutAsync_DeserializesSectionsAndTeams()
+	{
+		string json = """{"result":{"event":25,"name":"Test Major","sections":[],"teams":[]}}""";
+		var (api, _) = MakeApi(_ => JsonResponse(json));
+
+		var result = await api.GetTournamentLayoutAsync("25");
+
+		Assert.Equal("Test Major", result.Result.Name);
+	}
+
+	[Fact]
+	public async Task GetTournamentLayoutAsync_ThrowsKeyNotFound_WhenSteamReturns404()
+	{
+		var (api, _) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+		await Assert.ThrowsAsync<KeyNotFoundException>(() => api.GetTournamentLayoutAsync("missing-event"));
+	}
+
+	[Fact]
+	public async Task GetTournamentLayoutAsync_ThrowsOnOtherFailureStatusCodes()
+	{
+		var (api, _) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+		await Assert.ThrowsAsync<HttpRequestException>(() => api.GetTournamentLayoutAsync("25"));
+	}
+
+	[Fact]
+	public async Task GetUserPredictionsAsync_SendsEventSteamIdAndAuthCode_AndDeserializesPicks()
+	{
+		string json = """{"result":{"picks":[{"groupId":1,"index":0,"pick":42}]}}""";
+		var (api, handler) = MakeApi(_ => JsonResponse(json));
+
+		var result = await api.GetUserPredictionsAsync("76500000000000001", "25", "auth-code-abc");
+
+		string query = handler.LastRequest!.RequestUri!.Query;
+		Assert.Contains("event=25", query);
+		Assert.Contains("steamid=76500000000000001", query);
+		Assert.Contains("steamidkey=auth-code-abc", query);
+		Assert.Equal(42, result.Result.Picks.Single().Pick);
+	}
+
+	private static List<Team> TwoTeams() =>
+	[
+		new() { Logo = "teamA", TeamId = 1, ItemId = 100 },
+		new() { Logo = "teamB", TeamId = 2, ItemId = 200 }
+	];
+
+	[Fact]
+	public async Task PostUserPredictionsAsync_EncodesEveryPick_WithItsOwnTeamAndItemId()
+	{
+		var (api, handler) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+		await api.PostUserPredictionsAsync(["teamA", "teamB"], TwoTeams(), sectionId: 5, groupId: 9, "76500000000000001", "25", "auth-code-abc");
+
+		var form = HttpUtility.ParseQueryString(handler.LastRequestBody!);
+		Assert.Equal("25", form["event"]);
+		Assert.Equal("76500000000000001", form["steamId"]);
+		Assert.Equal("auth-code-abc", form["steamIdKey"]);
+		Assert.Equal("1", form["pickId"]);
+		Assert.Equal("100", form["itemId"]);
+		Assert.Equal("2", form["pickId1"]);
+		Assert.Equal("200", form["itemId1"]);
+	}
+
+	[Fact]
+	public async Task PostUserPredictionsAsync_ThrowsOnFailureStatusCode()
+	{
+		var (api, _) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.BadRequest));
+
+		await Assert.ThrowsAsync<HttpRequestException>(() =>
+			api.PostUserPredictionsAsync(["teamA"], TwoTeams(), sectionId: 5, groupId: 9, "76500000000000001", "25", "auth-code-abc"));
+	}
+
+	private static List<Section> ThreePlayoffSections() =>
+	[
+		new() { SectionId = 1, Name = "Quarter-Finals", Groups = [new() { GroupId = 10, Name = "QF1" }, new() { GroupId = 11, Name = "QF2" }, new() { GroupId = 12, Name = "QF3" }, new() { GroupId = 13, Name = "QF4" }] },
+		new() { SectionId = 2, Name = "Semi-Finals", Groups = [new() { GroupId = 20, Name = "SF1" }, new() { GroupId = 21, Name = "SF2" }] },
+		new() { SectionId = 3, Name = "Final", Groups = [new() { GroupId = 30, Name = "GF" }] }
+	];
+
+	private static List<Team> EightPlayoffTeams() =>
+		[.. Enumerable.Range(1, 8).Select(i => new Team { Logo = $"team{i}", TeamId = i, ItemId = (ulong)(1000 + i) })];
+
+	[Fact]
+	public async Task PostPlayoffPredictionsAsync_EncodesQuarterFinalsSemiFinalsAndTheGrandFinal()
+	{
+		var (api, handler) = MakeApi(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+		// Bracket order per SteamAPI.HandleQuarters/HandleSemis/HandleFinal: picks[0] is the
+		// champion, picks[1-2] the semi-final winners, picks[3-6] the quarter-final winners.
+		List<string> picks = ["team1", "team2", "team3", "team4", "team5", "team6", "team7"];
+
+		await api.PostPlayoffPredictionsAsync(picks, EightPlayoffTeams(), ThreePlayoffSections(), "76500000000000001", "25", "auth-code-abc");
+
+		var form = HttpUtility.ParseQueryString(handler.LastRequestBody!);
+		Assert.Equal("25", form["event"]);
+		Assert.Equal("76500000000000001", form["steamid"]);
+		Assert.Equal("auth-code-abc", form["steamidkey"]);
+
+		// Quarter-final 1 (picks[3] = team4) lands at the unsuffixed key.
+		Assert.Equal("10", form["groupId"]);
+		Assert.Equal("4", form["pickId"]);
+		// Quarter-final 2 (picks[4] = team5) lands at the "1" suffix.
+		Assert.Equal("11", form["groupId1"]);
+		Assert.Equal("5", form["pickId1"]);
+
+		// Semi-final 1 (picks[1] = team2) lands at the "4" suffix (i + 4, per HandleSemis).
+		Assert.Equal("20", form["groupId4"]);
+		Assert.Equal("2", form["pickId4"]);
+
+		// Grand final winner (picks[0] = team1) always lands at the "6" suffix.
+		Assert.Equal("30", form["groupid6"]);
+		Assert.Equal("1", form["pickid6"]);
+	}
+}

--- a/tests/PickemsPlanter.Tests/Pages/PickEms/PlayoffsModelTests.cs
+++ b/tests/PickemsPlanter.Tests/Pages/PickEms/PlayoffsModelTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using PickemsPlanter.Services;
+using System.Security.Claims;
+using Xunit;
+
+namespace PickemsPlanter.Pages.PickEms;
+
+public class PlayoffsModelTests
+{
+	private readonly IPickemsService _pickemsService = Substitute.For<IPickemsService>();
+	private readonly IHttpContextAccessor _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+	private readonly IUserPredictionsCachingService _cachingService = Substitute.For<IUserPredictionsCachingService>();
+
+	private const string AuthenticatedSteamId = "76500000000000001";
+	private const string EventId = "25";
+
+	private PlayoffsModel Model(string? steamIdClaim = AuthenticatedSteamId)
+	{
+		var httpContext = new DefaultHttpContext
+		{
+			User = new ClaimsPrincipal(new ClaimsIdentity(steamIdClaim is null
+				? []
+				: [new Claim(ClaimTypes.NameIdentifier, steamIdClaim)]))
+		};
+		_httpContextAccessor.HttpContext.Returns(httpContext);
+
+		return new(_pickemsService, _httpContextAccessor, _cachingService)
+		{
+			EventId = EventId,
+			EventName = "Test Event"
+		};
+	}
+
+	// Regression coverage for #151: SteamId must come from the authenticated cookie claim,
+	// never from a client-supplied route/query value, or any logged-in user could view or
+	// overwrite another user's picks by editing the URL.
+	[Fact]
+	public void SteamId_IsDerivedFromTheAuthenticatedClaim_NotFromAnyBoundRouteValue()
+	{
+		var model = Model(steamIdClaim: "76500000000000099");
+
+		Assert.Equal("76500000000000099", model.SteamId);
+	}
+
+	[Fact]
+	public async Task OnGetPicks_UsesTheAuthenticatedUsersSteamId()
+	{
+		var model = Model();
+
+		await model.OnGetPicks();
+
+		await _pickemsService.Received(1).GetPlayoffPicksAsync(AuthenticatedSteamId, EventId);
+	}
+
+	[Fact]
+	public async Task OnGetPicksAllowed_ReturnsTheServiceValue()
+	{
+		_pickemsService.GetPlayoffsPicksAllowedAsync(EventId).Returns(true);
+		var model = Model();
+
+		JsonResult result = await model.OnGetPicksAllowed();
+
+		Assert.Equal(true, result.Value);
+	}
+
+	[Fact]
+	public async Task OnGetTeamNames_ReturnsTheTeamNameMapForTheEvent()
+	{
+		Dictionary<string, string> map = new() { ["team1"] = "Team One" };
+		_pickemsService.GetTeamNameMapAsync(EventId).Returns(map);
+		var model = Model();
+
+		JsonResult result = await model.OnGetTeamNames();
+
+		Assert.Same(map, result.Value);
+	}
+
+	[Fact]
+	public async Task OnGetImages_ReturnsTheTeamsInPlayoffs()
+	{
+		List<string> teams = ["team1", "team2"];
+		_pickemsService.GetTeamsInPlayoffsAsync(EventId).Returns(teams);
+		var model = Model();
+
+		JsonResult result = await model.OnGetImages();
+
+		Assert.Same(teams, result.Value);
+	}
+
+	[Fact]
+	public async Task OnGetResults_ReturnsThePlayoffResults()
+	{
+		List<string> results = ["team1", "team2"];
+		_pickemsService.GetPlayoffResultsAsync(EventId).Returns(results);
+		var model = Model();
+
+		JsonResult result = await model.OnGetResults();
+
+		Assert.Same(results, result.Value);
+	}
+
+	[Fact]
+	public async Task OnPostSendPicks_LooksUpTheAuthCode_ForTheAuthenticatedUsersSteamId_NotAnyOtherId()
+	{
+		var model = Model();
+		_cachingService.GetAuthCodeFromCacheAsync(EventId, AuthenticatedSteamId).Returns("auth-code-123");
+
+		await model.OnPostSendPicks("picks-payload");
+
+		await _cachingService.Received(1).GetAuthCodeFromCacheAsync(EventId, AuthenticatedSteamId);
+		await _pickemsService.Received(1).PostPlayoffPickemsAsync("picks-payload", AuthenticatedSteamId, EventId, "auth-code-123");
+	}
+
+	[Fact]
+	public async Task OnPostSendPicks_RedirectsWithoutLeakingSteamIdAsARouteValue()
+	{
+		var model = Model();
+		_cachingService.GetAuthCodeFromCacheAsync(EventId, AuthenticatedSteamId).Returns("auth-code-123");
+
+		var result = await model.OnPostSendPicks("picks-payload");
+
+		var redirect = Assert.IsType<RedirectToPageResult>(result);
+		Assert.DoesNotContain("SteamId", redirect.RouteValues!.Keys);
+		Assert.Equal(EventId, redirect.RouteValues["EventId"]);
+	}
+}

--- a/tests/PickemsPlanter.Tests/Pages/PickEms/StageModelTests.cs
+++ b/tests/PickemsPlanter.Tests/Pages/PickEms/StageModelTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using PickemsPlanter.Models.Event;
+using PickemsPlanter.Services;
+using System.Security.Claims;
+using Xunit;
+
+namespace PickemsPlanter.Pages.PickEms;
+
+public class StageModelTests
+{
+	private readonly IPickemsService _pickemsService = Substitute.For<IPickemsService>();
+	private readonly IHttpContextAccessor _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+	private readonly IUserPredictionsCachingService _cachingService = Substitute.For<IUserPredictionsCachingService>();
+
+	private const string AuthenticatedSteamId = "76500000000000001";
+	private const string EventId = "25";
+
+	private StageModel Model(string? steamIdClaim = AuthenticatedSteamId)
+	{
+		var httpContext = new DefaultHttpContext
+		{
+			User = new ClaimsPrincipal(new ClaimsIdentity(steamIdClaim is null
+				? []
+				: [new Claim(ClaimTypes.NameIdentifier, steamIdClaim)]))
+		};
+		_httpContextAccessor.HttpContext.Returns(httpContext);
+
+		return new(_pickemsService, _httpContextAccessor, _cachingService)
+		{
+			EventId = EventId,
+			EventName = "Test Event",
+			Stage = Stages.Stage1
+		};
+	}
+
+	// Regression coverage for #151: SteamId must come from the authenticated cookie claim,
+	// never from a client-supplied route/query value, or any logged-in user could view or
+	// overwrite another user's picks by editing the URL.
+	[Fact]
+	public void SteamId_IsDerivedFromTheAuthenticatedClaim_NotFromAnyBoundRouteValue()
+	{
+		var model = Model(steamIdClaim: "76500000000000099");
+
+		Assert.Equal("76500000000000099", model.SteamId);
+	}
+
+	[Fact]
+	public async Task OnGetPicks_UsesTheAuthenticatedUsersSteamId()
+	{
+		var model = Model();
+
+		await model.OnGetPicks();
+
+		await _pickemsService.Received(1).GetStagePicksAsync(Stages.Stage1, AuthenticatedSteamId, EventId);
+	}
+
+	[Fact]
+	public async Task OnGetPicksAllowed_ReturnsTheServiceValue()
+	{
+		_pickemsService.GetStagePicksAllowedAsync(Stages.Stage1, EventId).Returns(true);
+		var model = Model();
+
+		JsonResult result = await model.OnGetPicksAllowed();
+
+		Assert.Equal(true, result.Value);
+	}
+
+	[Fact]
+	public async Task OnGetTeamNames_ReturnsTheTeamNameMapForTheEvent()
+	{
+		Dictionary<string, string> map = new() { ["team1"] = "Team One" };
+		_pickemsService.GetTeamNameMapAsync(EventId).Returns(map);
+		var model = Model();
+
+		JsonResult result = await model.OnGetTeamNames();
+
+		Assert.Same(map, result.Value);
+	}
+
+	[Fact]
+	public async Task OnGetImages_ReturnsTheTeamsInTheStage()
+	{
+		List<string> teams = ["team1", "team2"];
+		_pickemsService.GetTeamsInStageAsync(Stages.Stage1, EventId).Returns(teams);
+		var model = Model();
+
+		JsonResult result = await model.OnGetImages();
+
+		Assert.Same(teams, result.Value);
+	}
+
+	[Fact]
+	public async Task OnGetResults_ReturnsTheStageResults()
+	{
+		List<string> results = ["team1", "team2"];
+		_pickemsService.GetStageResultsAsync(Stages.Stage1, EventId).Returns(results);
+		var model = Model();
+
+		JsonResult result = await model.OnGetResults();
+
+		Assert.Same(results, result.Value);
+	}
+
+	[Fact]
+	public async Task OnPostSendPicks_LooksUpTheAuthCode_ForTheAuthenticatedUsersSteamId_NotAnyOtherId()
+	{
+		var model = Model();
+		_cachingService.GetAuthCodeFromCacheAsync(EventId, AuthenticatedSteamId).Returns("auth-code-123");
+
+		await model.OnPostSendPicks("picks-payload");
+
+		await _cachingService.Received(1).GetAuthCodeFromCacheAsync(EventId, AuthenticatedSteamId);
+		await _pickemsService.Received(1).PostStagePickemsAsync(Stages.Stage1, "picks-payload", AuthenticatedSteamId, EventId, "auth-code-123");
+	}
+
+	[Fact]
+	public async Task OnPostSendPicks_RedirectsWithoutLeakingSteamIdAsARouteValue()
+	{
+		var model = Model();
+		_cachingService.GetAuthCodeFromCacheAsync(EventId, AuthenticatedSteamId).Returns("auth-code-123");
+
+		var result = await model.OnPostSendPicks("picks-payload");
+
+		var redirect = Assert.IsType<RedirectToPageResult>(result);
+		Assert.DoesNotContain("SteamId", redirect.RouteValues!.Keys);
+		Assert.Equal(EventId, redirect.RouteValues["EventId"]);
+		Assert.Equal(Stages.Stage1, redirect.RouteValues["stage"]);
+	}
+}


### PR DESCRIPTION
## Summary
Part of #153 — adds the C# portion of the test-coverage gap:

- `StageModelTests`/`PlayoffsModelTests`: covers all GET handlers plus `OnPostSendPicks`, including regression coverage that `SteamId` is always derived from the authenticated claim (#151) and is never leaked back out as a redirect route value.
- `SteamAPITests`/`LoginAPITests`: drives the real `HttpClient` through a fake `HttpMessageHandler` to assert request URLs, form-encoded bodies, and response deserialization — including the fiddly playoffs bracket-position encoding in `HandleQuarters`/`HandleSemis`/`HandleFinal`.
- Dropped the `required` modifier from `SteamId`/`PersonaName`/`Avatar` on both page models — they're always computed from `HttpContext` via a field initializer, never meant to be supplied by a caller, and `required` was actively fighting direct-construction testability (would've forced tests to stomp the claim-derived value just to satisfy the compiler).

**Not included**: the JS Swiss-bracket pairing-avoidance logic (`resolveRepeatingMatchups`/`hasConflict` in `wwwroot/js/Simulator/simulator.js`) that #153 also calls out. There's no JS test tooling in this repo at all yet — adding one is a real decision (test runner choice, whether to convert those scripts to ES modules for testability) that needs its own discussion, so it's left for a follow-up rather than bundled in here.

## Test plan
- [x] `dotnet build src/PickemsPlanter.sln` — succeeds, 0 warnings/errors
- [x] `dotnet test src/PickemsPlanter.sln` — 169/169 passing (28 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)